### PR TITLE
Fix content consistency: lesson count, CTA wording, Ko-fi URL, and SEO title duplication

### DIFF
--- a/src/components/DonationSection.astro
+++ b/src/components/DonationSection.astro
@@ -6,7 +6,7 @@ interface Props {
 const { showOnHomepage = false } = Astro.props;
 
 const paypalLink = 'https://paypal.me/MinhTriVo?locale.x=en_US&country.x=VN';
-const kofiId = 'L3L61PX2L8';
+const kofiUrl = 'https://ko-fi.com/cc4marketing';
 ---
 
 <section class="donation-section" class:list={[showOnHomepage && 'donation-homepage']}>
@@ -33,7 +33,7 @@ const kofiId = 'L3L61PX2L8';
           <div class="method-icon">☕</div>
           <h4>Ko-fi Support</h4>
           <p>Buy me a coffee or send a tip</p>
-          <a href="https://ko-fi.com/L3L61PX2L8" target="_blank" rel="noopener noreferrer" class="donation-btn kofi-btn">
+          <a href={kofiUrl} target="_blank" rel="noopener noreferrer" class="donation-btn kofi-btn">
             Support on Ko-fi →
           </a>
         </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -33,7 +33,11 @@ const {
 const siteUrl = "https://cc4.marketing";
 const currentPath = Astro.url.pathname;
 const canonicalUrl = canonical || `${siteUrl}${currentPath}`;
-const fullTitle = title.includes("CC4") ? title : `${title} | Claude Code for Marketers`;
+const siteName = "Claude Code for Marketers";
+const normalizedTitle = title.trim();
+const fullTitle = normalizedTitle.endsWith(siteName)
+  ? normalizedTitle
+  : `${normalizedTitle} | ${siteName}`;
 const ogImage = image.startsWith("http") ? image : `${siteUrl}${image}`;
 
 // JSON-LD Structured Data

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -59,7 +59,7 @@ const stats = [
     title="Claude Code for Marketers"
     subtitle="Learn IN Claude Code. Work 10x Faster."
     description="This course is taught entirely inside Claude Code. You'll install it, clone the repo, then type /start-0-0 to begin. Claude guides you through each lesson interactively."
-    primaryCta={{ label: 'Download Course →', href: '/download' }}
+    primaryCta={{ label: 'Get Course Access →', href: '/download' }}
     secondaryCta={{ label: 'Browse Docs', href: '#modules' }}
   />
 
@@ -89,7 +89,7 @@ const stats = [
             <span class="install-number">1</span>
             <div class="install-content">
               <strong>Download the Course</strong>
-              <p>Go to the <a href="/download">Download page</a>, enter your email, and click "Download Course".</p>
+              <p>Go to the <a href="/download">Download page</a>, enter your email, then click the download button.</p>
             </div>
           </div>
           <div class="install-step">
@@ -188,7 +188,7 @@ const stats = [
       <div class="section-header">
         <div class="section-label">Three Modules</div>
         <h2 class="section-title">Your Learning Path</h2>
-        <p class="section-description">Master AI-powered marketing in 2 weeks. Three modules. 18 lessons. Real transformations.</p>
+        <p class="section-description">Master AI-powered marketing in 2 weeks. Three modules. 16 lessons. Real transformations.</p>
       </div>
 
       <div class="modules-grid">


### PR DESCRIPTION
## What this fixes
This PR addresses content consistency and metadata/link issues found during the cc4.marketing audit.

### ✅ Changes
1. **Lesson count consistency on homepage**
   - Updated homepage modules section from `18 lessons` -> `16 lessons` to match current module pages (3 + 7 + 6).

2. **CTA wording consistency for download flow**
   - Changed hero primary CTA from `Download Course →` to `Get Course Access →`.
   - Updated quickstart step copy to avoid hard-coded button text mismatch (`click the download button`).

3. **Ko-fi URL normalization**
   - Unified donation link in `DonationSection` to `https://ko-fi.com/cc4marketing`.

4. **SEO title duplication prevention**
   - Improved `BaseLayout` title logic to avoid duplicate suffix patterns like:
     - `... | Claude Code for Marketers | Claude Code for Marketers`

## Files changed
- `src/pages/index.astro`
- `src/components/DonationSection.astro`
- `src/layouts/BaseLayout.astro`

## Verification
- Local build passes: `npm run build`

## Context
Related audit issue opened in another repo for tracking: cc4-marketing/cc4.marketing#6
