### PR TITLE
fix: content consistency audit — lesson counts, Ko-fi links, SEO titles

### DIFF
--- a/src/components/DonationSection.astro
+++ b/src/components/DonationSection.astro
@@ -6,7 +6,7 @@ interface Props {
 const { showOnHomepage = false } = Astro.props;
 
 const paypalLink = 'https://paypal.me/MinhTriVo?locale.x=en_US&country.x=VN';
-const kofiId = 'L3L61PX2L8';
+const kofiId = 'cc4marketing';
 ---
 
 <section class="donation-section" class:list={[showOnHomepage && 'donation-homepage']}>
@@ -33,7 +33,7 @@ const kofiId = 'L3L61PX2L8';
           <div class="method-icon">☕</div>
           <h4>Ko-fi Support</h4>
           <p>Buy me a coffee or send a tip</p>
-          <a href="https://ko-fi.com/L3L61PX2L8" target="_blank" rel="noopener noreferrer" class="donation-btn kofi-btn">
+          <a href="https://ko-fi.com/cc4marketing" target="_blank" rel="noopener noreferrer" class="donation-btn kofi-btn">
             Support on Ko-fi →
           </a>
         </div>

--- a/src/config/siteData.ts
+++ b/src/config/siteData.ts
@@ -28,7 +28,7 @@ export const siteData = {
         number: 0,
         title: 'Getting Started',
         description: 'Install Claude Code and get your first taste of AI-powered marketing.',
-        lessonCount: '3 Lessons • 30 minutes',
+        lessonCount: '4 Lessons • 30 minutes',
         lessons: ['Introduction', 'Installation', 'First Task'],
         href: '/modules/0/introduction'
       },

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -33,7 +33,7 @@ const {
 const siteUrl = "https://cc4.marketing";
 const currentPath = Astro.url.pathname;
 const canonicalUrl = canonical || `${siteUrl}${currentPath}`;
-const fullTitle = title.includes("CC4") ? title : `${title} | Claude Code for Marketers`;
+const fullTitle = (title.includes("CC4") || title.includes("Claude Code for Marketers")) ? title : `${title} | Claude Code for Marketers`;
 const ogImage = image.startsWith("http") ? image : `${siteUrl}${image}`;
 
 // JSON-LD Structured Data
@@ -63,7 +63,7 @@ const courseSchema = {
   },
   "educationalLevel": "Beginner to Intermediate",
   "teaches": ["AI Marketing", "Content Creation", "Marketing Automation", "Claude Code"],
-  "numberOfCredits": "16 lessons",
+  "numberOfCredits": "17 lessons",
   "timeRequired": "PT10H",
   "inLanguage": "en",
   "isAccessibleForFree": true,

--- a/src/pages/brand-guide.astro
+++ b/src/pages/brand-guide.astro
@@ -15,7 +15,7 @@ try {
 }
 ---
 
-<BaseLayout title="Brand Guidelines | Claude Code for Marketers" description="Visual identity, voice, and tone for the CC4.Marketing platform.">
+<BaseLayout title="Brand Guidelines" description="Visual identity, voice, and tone for the CC4.Marketing platform.">
   <Header />
   
   <div class="brand-hero">

--- a/src/pages/download.astro
+++ b/src/pages/download.astro
@@ -4,7 +4,7 @@ import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 ---
 
-<BaseLayout title="Subscribe | Claude Code for Marketers" description="Subscribe for course updates and bonus content">
+<BaseLayout title="Subscribe" description="Subscribe for course updates and bonus content">
   <Header />
   
   <section class="download-section">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -147,7 +147,7 @@ import DonationSection from '../components/DonationSection.astro';
       <div class="section-header">
         <div class="section-label">Three Modules</div>
         <h2 class="section-title">Your Learning Path</h2>
-        <p class="section-description">Master AI-powered marketing in 2 weeks. Three modules. 18 lessons. Real transformations.</p>
+        <p class="section-description">Master AI-powered marketing in 2 weeks. Three modules. 17 lessons. Real transformations.</p>
       </div>
 
       <div class="modules-grid">


### PR DESCRIPTION
## Summary

Fixes content consistency issues identified in cc4-marketing/cc4.marketing#6.

- **Lesson count mismatch**: JSON-LD said 16, homepage said 18, actual count is 17. All updated to 17.
- **Module 0 card**: Showed "3 Lessons" but has 4 lesson pages. Updated to "4 Lessons".
- **Ko-fi link inconsistency**: DonationSection used `ko-fi.com/L3L61PX2L8`, Footer used `ko-fi.com/cc4marketing`. Unified to the vanity URL (`cc4marketing`).
- **SEO title duplication**: Title template only checked for "CC4" before appending site name suffix, causing pages like "Subscribe | Claude Code for Marketers | Claude Code for Marketers". Fixed to also check for the full site name. Removed redundant site name from download and brand-guide page titles.
- **CTA mismatch**: Already addressed in commit 047d1c3. Current copy ("Subscribe & Get the Link") accurately describes the Substack subscribe flow.

## Files changed
- `src/layouts/BaseLayout.astro` — title template fix + JSON-LD lesson count
- `src/pages/index.astro` — homepage lesson count 18→17
- `src/config/siteData.ts` — Module 0 lesson count 3→4
- `src/components/DonationSection.astro` — Ko-fi URL unified
- `src/pages/download.astro` — remove redundant site name from title
- `src/pages/brand-guide.astro` — remove redundant site name from title

## Test plan
- [ ] Verify homepage displays "17 lessons"
- [ ] Verify Module 0 card shows "4 Lessons"
- [ ] Verify Ko-fi links in both footer and donation section go to `ko-fi.com/cc4marketing`
- [ ] Verify page titles don't duplicate "Claude Code for Marketers" (check Subscribe, Brand Guidelines pages)
- [ ] Verify JSON-LD structured data shows "17 lessons"
- [ ] Build succeeds without errors

Closes cc4-marketing/cc4.marketing#6

🤖 Generated with [Claude Code](https://claude.com/claude-code)