### PR TITLE
fix(seo): three HIGH-priority audit items

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -63,6 +63,13 @@ export default defineConfig({
     mdx(),
     sitemap({
       customPages: [...modulePages, ...blogPages],
+      // Exclude dev-only routes from the sitemap. These are gated behind
+      // import.meta.env.DEV (404 in production) and Disallowed in robots.txt;
+      // including them in the sitemap sends a contradictory signal to crawlers.
+      filter: (page) =>
+        !page.includes('/og-preview') &&
+        !page.includes('/og/preview') &&
+        !page.includes('/og/debug'),
       serialize(item) {
         const url = item.url;
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -194,7 +194,14 @@ const breadcrumbSchema = {
   <!-- JSON-LD Structured Data -->
   <script type="application/ld+json" set:html={JSON.stringify(websiteSchema)} />
   {showCourseSchema && <script type="application/ld+json" set:html={JSON.stringify(courseSchema)} />}
-  {showBreadcrumb && <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />}
+  {/* BaseLayout only knows the "Home" item, which is a useless 1-item
+      BreadcrumbList. Emit only when the calling page has supplied an
+      itemListElement chain with ≥2 items (currently none do, so this
+      effectively never fires from BaseLayout — pages provide their own
+      BreadcrumbList script). */}
+  {showBreadcrumb && breadcrumbSchema.itemListElement.length >= 2 && (
+    <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
+  )}
 </head>
 <body>
   <HelloBar {...promoConfig.helloBar} />

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -94,6 +94,18 @@ const articleSchema = {
     ],
   },
 };
+
+// Top-level BreadcrumbList — Google reads this independent of the
+// BlogPosting nesting and uses it to render breadcrumb trails in SERP.
+const breadcrumbListSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  'itemListElement': [
+    { '@type': 'ListItem', 'position': 1, 'name': 'Home', 'item': 'https://cc4.marketing/' },
+    { '@type': 'ListItem', 'position': 2, 'name': 'Blog', 'item': 'https://cc4.marketing/blog/' },
+    { '@type': 'ListItem', 'position': 3, 'name': post.data.title, 'item': `https://cc4.marketing/blog/${slug}/` },
+  ],
+};
 ---
 
 <BaseLayout
@@ -111,6 +123,7 @@ const articleSchema = {
   <Header />
 
   <script type="application/ld+json" set:html={JSON.stringify(articleSchema)} />
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbListSchema)} />
 
   <article class="blog-post">
     <div class="blog-post-inner">


### PR DESCRIPTION
## Summary

Fixes the 3 HIGH-priority items from the 2026-04-15 SEO audit:

1. **`/og-preview/` leaked into sitemap-0.xml** while also being Disallowed in robots.txt — contradictory signal that Search Console flags. Added a sitemap `filter` to drop dev-only OG routes.
2. **Blog posts missing standalone BreadcrumbList JSON-LD.** The breadcrumb was nested inside `BlogPosting.breadcrumb`, but Google needs a top-level `<script type="application/ld+json">` to render breadcrumb trails in SERP. Now emitted alongside the BlogPosting schema.
3. **1-item BreadcrumbList on homepage** (and any page using BaseLayout's default). Useless schema — Google ignores 1-item lists. BaseLayout now skips emission unless the chain has ≥2 items. Pages that need breadcrumbs supply their own (`[slug].astro` does).

## Testing
- Unit tests: 37/37 pass
- `npm run build`: clean
- Local sitemap inspection: `grep -E "og-preview|og/preview|og/debug" dist/client/sitemap-0.xml` → no matches ✓

## Post-Deploy Monitoring & Validation
- **Validation checks**
  - `curl -sS https://cc4.marketing/sitemap-0.xml | grep -E "og-preview|og/preview|og/debug"` → expect no matches
  - `curl -sS https://cc4.marketing/blog/claude-code-for-marketing-guide-2026 | grep -c BreadcrumbList` → expect ≥1
  - `curl -sS https://cc4.marketing/ | grep -c BreadcrumbList` → expect 0 (1-item suppressed)
  - Google Rich Results Test on a blog post URL → BreadcrumbList should appear as eligible
- **Failure signal / rollback trigger**
  - Search Console reports new "Indexed though blocked by robots.txt" warnings → rollback the sitemap filter (unlikely; we're removing entries, not adding)
  - Rich Results Test fails on blog post → revert breadcrumb commit and re-test
- **Validation window & owner**
  - Window: first 48h after deploy + first weekly Search Console crawl
  - Owner: @trivo

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)