### PR TITLE
feat: Module 3 capstone (sigil), lesson sidebar, /modules/ hub, GA4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - `src/styles/` stores global styles and design tokens.
 - `src/content/` and `src/content.config.ts` define content collections and schemas.
 - `public/` is for static assets served as-is (images, icons, downloads).
+- `docs/solutions/` documents past problems (bugs, best practices, workflow patterns), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in documented areas.
 
 ## Build, Test, and Development Commands
 - `npm install` installs dependencies.

--- a/docs/plans/2026-05-16-001-feat-sigil-companion-integration-plan.md
+++ b/docs/plans/2026-05-16-001-feat-sigil-companion-integration-plan.md
@@ -1,0 +1,103 @@
+---
+title: Sigil Companion Integration (Capstone Module 3)
+type: feat
+status: draft
+date: 2026-05-16
+origin: external — agreement with blacklogos/sigil maintainer (Tri)
+---
+
+# Sigil Companion Integration (Capstone Module 3)
+
+## Overview
+
+Add a Module 3 capstone lesson — `3.1 Ship a Real Follow-Up with sigil` — that bridges Modules 0–2 into a working, shippable marketing artifact: a personalized post-event follow-up campaign powered by [blacklogos/sigil](https://github.com/blacklogos/sigil), an open-source MIT-licensed CLI that uses a custom Claude Code slash command (`/email-rewrite`) to handcraft per-recipient sentences.
+
+This integration is **bidirectional**:
+
+- cc4.marketing gains a hands-on capstone that turns Module 1's "build custom AI agents" concept into a real tool a learner can run end-to-end in 75 min.
+- Sigil gains a warm distribution channel — the existing cc4.marketing audience is the exact ICP for a per-recipient handcrafted email workflow.
+
+Neither project merges. Each stays in its own repo with its own license and voice. The integration is a cross-link + a single lesson + a done-with-you funnel.
+
+## Goals
+
+1. **One lesson, well-shipped.** `src/content/modules/module-3/3.1-ship-with-sigil.mdx` is live, reviewed, and renders cleanly in the existing Astro pipeline.
+2. **Cross-promotion functional.** Sigil's README links here; this lesson links to the sigil repo. The course's existing "Course Complete" closer at 2.6 either updates to point at the capstone or stays put — author's call.
+3. **Done-with-you funnel.** The lesson's "When You're Stuck" section points at a done-with-you setup offer for learners who'd rather pair on the first campaign. Pricing test: $200 / $350 / $500 across the first 3 inquiries; lock the closer.
+
+## Non-Goals
+
+- Merging sigil into cc4-site (different repo, different concern)
+- Rewriting modules 0–2 to mention sigil (the capstone is bonus; modules 0–2 stay generic)
+- A SaaS or hosted version of sigil (not in scope, ever — sigil is a CLI by design)
+- A separate "sigil track" in the course (one lesson is enough until traffic justifies more)
+
+## Deliverables
+
+- [x] `src/content/modules/module-3/3.1-ship-with-sigil.mdx` — capstone lesson written, ~75 min hands-on, frontmatter matches existing schema (title, module: 3, lesson: 1, description, duration, objectives, order: 18)
+- [ ] `module-3` registered in the navigation (verify it shows up in `/modules/`)
+- [ ] Cross-link in sigil's README → this lesson URL (sigil-side change; outside this repo's scope but tracked here)
+- [ ] Optional: update 2.6's "Course Complete" closer to mention the bonus capstone (author's call)
+- [ ] Static "setup help" page or section linking to the done-with-you offer (author's call where it lives — homepage, `/services`, or off-site at mtri.me)
+- [ ] `npm run build` passes after adding module-3
+
+## Architecture Notes
+
+The capstone lesson follows existing conventions exactly:
+
+- File: `.mdx` in `src/content/modules/module-3/`
+- Frontmatter: matches `src/content.config.ts` schema (`title`, `module`, `lesson`, `description`, `duration?`, `objectives?[]`, `order`)
+- Voice: Planerio fictional client (consistent with module-2 lessons)
+- Style: matches existing tutorial flow — Hook → Why → Prerequisites → Steps → Reflection → Stretch Goals → Takeaways
+- Length: ~12KB markdown, in line with module-2 lessons (~9–12KB each)
+
+No code changes to `src/`, `src/pages/`, or `src/components/` should be needed unless the modules listing page hard-codes `module-0`, `module-1`, `module-2`. Verify with `npm run build` + `/modules/` route.
+
+## Risks
+
+1. **Prerequisite gap.** The lesson assumes Cloudflare comfort (account, Workers, R2, KV). If a meaningful slice of cc4 learners can't get past Step 3, the funnel breaks. **Mitigation**: the lesson explicitly calls prerequisites up front and points at the done-with-you offer as the escape hatch — self-selection is a feature.
+2. **Sigil version drift.** Sigil is at 0.1.0; future bumps could break the lesson's exact commands. **Mitigation**: the lesson references `sig --version` and the author keeps a "lesson pinned against sigil 0.1.0" note in `blacklogos/sigil/plans/cc4-marketing-integration.md`. Re-review after sigil major version bumps.
+3. **Voice mismatch.** Sigil's templates are VN-first; cc4.marketing is English-first. **Mitigation**: the lesson uses English copy for the example values (Planerio CMO Roundtable) and surfaces the English template option (`BODY_TEMPLATE=templates/body.en.md`) explicitly in the stretch goals.
+4. **Audience leakage to done-with-you.** Healthy thing; track inquiries.
+
+## Implementation Plan
+
+**Phase 1 — Author review & merge (this week)**
+
+- [ ] Author reads `src/content/modules/module-3/3.1-ship-with-sigil.mdx`, edits for voice
+- [ ] `npm run dev` — verify the lesson renders at `/modules/module-3/3.1-ship-with-sigil/`
+- [ ] `npm run build` — verify no Astro / Zod schema errors
+- [ ] Commit (`feat: add module 3 capstone — ship with sigil`)
+- [ ] Push, let GitHub Actions deploy
+
+**Phase 2 — Cross-link + announce (within 2 weeks of Phase 1)**
+
+- [ ] Sigil README → add link to the deployed lesson URL
+- [ ] Optional: update 2.6's closer to mention the bonus capstone
+- [ ] Short post on cc4.marketing's existing channels announcing the capstone
+
+**Phase 3 — Funnel & metrics (within 30 days)**
+
+- [ ] Done-with-you setup offer surfaces somewhere durable (homepage, /services, off-site)
+- [ ] Track: cc4 → sigil click-throughs (UTM param `?utm_source=cc4_capstone`)
+- [ ] Track: setup-help inquiries (single inbox / Linear list)
+
+## Success Metrics
+
+- Capstone lesson published and renders ✓ (binary)
+- ≥1 learner reaches Step 10 (real send) within 30 days of publication — survey via the existing course feedback channel
+- ≥1 setup-help inquiry within 30 days (the only metric that pays rent)
+- Sigil repo gains visible traffic in GitHub Insights → Traffic after the capstone goes live
+
+## References
+
+- Capstone lesson source: `src/content/modules/module-3/3.1-ship-with-sigil.mdx`
+- Sigil repo: <https://github.com/blacklogos/sigil>
+- Sigil's mirror of this plan (its view of the integration): `<sigil-repo>/plans/cc4-marketing-integration.md`
+- Sigil's locked plan that shipped the v2 work this capstone teaches: `<sigil-repo>/plans/sigil-v2.md`
+
+## Decisions (resolved 2026-05-17)
+
+1. **2.6 closer**: update to point at module-3 capstone.
+2. **Done-with-you page**: lives on cc4-site at a new `/services` route.
+3. **Sigil version pin in frontmatter**: skip.

--- a/docs/solutions/ui-bugs/mdx-curly-braces-silent-empty-prose-astro-20260517.md
+++ b/docs/solutions/ui-bugs/mdx-curly-braces-silent-empty-prose-astro-20260517.md
@@ -1,0 +1,84 @@
+---
+title: "MDX silent empty prose: unescaped curly braces in lesson body parsed as JSX expression"
+date: 2026-05-17
+category: docs/solutions/ui-bugs/
+module: Course Modules / MDX Lessons
+problem_type: ui_bug
+component: tooling
+severity: high
+symptoms:
+  - "MDX lesson route returns HTTP 200 but renders an empty <article class=\"prose\">"
+  - "No build error or dev-server warning logged"
+  - "Other lesson routes render correctly; only the newly-added file is blank"
+  - "Rendered HTML contains ~2 prose elements instead of the expected ~20+"
+  - "File on disk has full frontmatter and 200+ lines of body content"
+root_cause: wrong_api
+resolution_type: code_fix
+tags: [mdx, astro, curly-braces, jsx-expression, silent-failure, content-collections, authoring, lessons]
+---
+
+# MDX silent empty prose: unescaped curly braces in lesson body parsed as JSX expression
+
+## Problem
+A new MDX lesson rendered as **HTTP 200 with an empty `<article class="prose">`** — the route resolved, the layout shell mounted, but the body was silently dropped. No build or dev-server error appeared.
+
+## Symptoms
+- Route returns 200 OK, page title and chrome render normally.
+- `<article class="prose">` is nearly empty (~2 elements vs. ~22 on a working lesson).
+- No console error, no Astro/MDX warning in the dev server, no failed build.
+- Other lessons in the same module render fine; only the offending file is blank.
+- Frontmatter, imports, and component usage all look valid on inspection.
+
+## What Didn't Work
+- **Diffing frontmatter against a working lesson** — frontmatter was identical in shape; the bug was in the body.
+- **Eyeballing for unclosed JSX / malformed components** — there were no custom components on the broken line; the trigger was plain narrative prose.
+- **Searching for obvious MDX errors / dev-server logs** — MDX fails silently here, so log inspection yielded nothing.
+- **Comparing file length / line count** — file looked "normal size," which masked the issue.
+
+## Solution
+Wrap the interpolation-like literal in inline code (backticks) so the curly braces become text inside a `<code>` element, not an MDX JSX expression.
+
+```diff
+- No "Dear {firstname}." A real sentence per row.
++ No `"Dear {firstname}."` A real sentence per row.
+```
+
+Equivalent alternative — escape the brace with a backslash:
+
+```mdx
+No "Dear \{firstname}." A real sentence per row.
+```
+
+After the fix the same route returned a full body (52 prose elements; all section headings present).
+
+## Why This Works
+MDX is **not** plain Markdown — anywhere in the markdown body, `{ ... }` is parsed as a **JSX expression** and `<Capital...>` is parsed as a **JSX/HTML element**. When MDX sees `{firstname}` in prose, it tries to evaluate `firstname` as a JS identifier in scope. The identifier is undefined, so MDX bails on rendering the rest of the document body — but the route, layout, and frontmatter still resolve, producing the silent **200 + empty prose** signature.
+
+Wrapping the text in backticks turns it into an inline `<code>` node where braces are treated as literal characters. Backslash-escaping (`\{`) tells the MDX parser to treat that brace as a literal too. Either approach defuses the JSX trigger.
+
+The same hazard applies to angle brackets: `<SHEET_ID>` in plain prose would be parsed as a JSX tag. Inside fenced code blocks (```` ``` ````) or inline backticks, both `{...}` and `<...>` are safe.
+
+## Prevention
+- **Author rule:** any literal `{placeholder}`, `{{var}}`, `<TOKEN>`, or template-like syntax in MDX body must live inside backticks or a fenced code block — or be backslash-escaped (`\{`, `\<`).
+- **Spot the failure fast:** if a new lesson returns 200 but the page body looks empty, suspect an MDX JSX expression in prose before anything else.
+- **Pre-commit grep** for risky interpolations in plain prose (run from repo root):
+
+  ```bash
+  grep -nE '\{[a-zA-Z_]' src/content/modules/**/*.mdx
+  ```
+
+  Review each hit: if it's inside backticks or a fenced code block it's safe; if it's bare prose, wrap it in backticks or escape the brace.
+
+- **Also check for bare JSX-like tags** in prose:
+
+  ```bash
+  grep -nE '<[A-Za-z][A-Za-z0-9_]*' src/content/modules/**/*.mdx
+  ```
+
+  Anything that isn't an intentional component import or inside a code fence should be wrapped/escaped.
+
+- **Optional CI guardrail:** add a build-time check that compiles every MDX file with MDX's strict mode and fails on undefined identifier references in expressions.
+
+## Related Issues
+- [`docs/solutions/ui-bugs/portabletext-missing-code-image-handlers-BlogPublisher-20260426.md`](portabletext-missing-code-image-handlers-BlogPublisher-20260426.md) — sibling "silent content-rendering failure" in a different pipeline (PortableText/blog); useful pattern reference for "rendered HTML doesn't match source."
+- [`docs/solutions/seo-issues/faqpage-howto-schemas-lesson-descriptions-aeo-20260428.md`](../seo-issues/faqpage-howto-schemas-lesson-descriptions-aeo-20260428.md) — other doc touching lesson MDX authoring; helpful for authors landing here.

--- a/src/components/GoogleAnalytics.astro
+++ b/src/components/GoogleAnalytics.astro
@@ -1,0 +1,19 @@
+---
+// Google Analytics 4 — production only.
+// Reads PUBLIC_GA_MEASUREMENT_ID from env. Renders nothing if missing or in dev,
+// so Astro's preview/dev/CF preview deploys do not pollute the prod stream.
+const GA_ID = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
+const enabled = import.meta.env.PROD && typeof GA_ID === 'string' && GA_ID.startsWith('G-');
+---
+
+{enabled && (
+  <>
+    <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}></script>
+    <script is:inline define:vars={{ GA_ID }}>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', GA_ID);
+    </script>
+  </>
+)}

--- a/src/components/LessonPromoBanner.astro
+++ b/src/components/LessonPromoBanner.astro
@@ -9,10 +9,10 @@ interface Props {
 
 const {
     enabled = true,
-    storageKey = "lesson-promo-claudekit-v130",
+    storageKey = "lesson-promo-m3-sigil-capstone",
     cooldownDays = 3,
-    linkUrl = "https://claudekit.cc/?ref=BIZE9CYY",
-    releaseNotesUrl = "https://claudekit.cc/updates/claudekit-marketing/v1-3-0-the-biggest-update-yet?ref=BIZE9CYY"
+    linkUrl = "https://cc4.marketing/modules/3/ship-with-sigil/",
+    releaseNotesUrl = "https://github.com/blacklogos/sigil"
 } = Astro.props;
 ---
 
@@ -24,31 +24,31 @@ const {
             </svg>
         </button>
 
-        <div class="lesson-promo-badge">NEW RELEASE</div>
+        <div class="lesson-promo-badge">NEW CAPSTONE</div>
 
-        <h4 class="lesson-promo-title">ClaudeKit Marketing v1.3.0</h4>
+        <h4 class="lesson-promo-title">Module 3: Ship with sigil</h4>
 
         <p class="lesson-promo-desc">
-            30+ new skills. Full pipeline orchestration. AI video from your terminal. One command, entire marketing workflow.
+            Send personalized post-event follow-ups end-to-end with sigil &mdash; an open-source CLI built for marketers, inside Claude Code.
         </p>
 
         <ul class="lesson-promo-highlights">
-            <li>Play skill &mdash; research to tracking in one run</li>
-            <li>Referral, gamification, paid ads, CRO skills</li>
-            <li>Kling AI + ElevenLabs video/audio integration</li>
-            <li>8 MCP servers (GA4, Ads, SendGrid, Slack...)</li>
+            <li>75-minute hands-on capstone</li>
+            <li>Custom <code>/email-rewrite</code> slash command (Module 1 style)</li>
+            <li>Real send pipeline on Cloudflare Workers</li>
+            <li>Open-source CLI, MIT licensed</li>
         </ul>
 
         <div class="lesson-promo-actions">
-            <a href={linkUrl} target="_blank" rel="noopener noreferrer" class="lesson-promo-btn">
-                Check it out
+            <a href={linkUrl} class="lesson-promo-btn">
+                Start the lesson
             </a>
             <a href={releaseNotesUrl} target="_blank" rel="noopener noreferrer" class="lesson-promo-link">
-                Release notes &rarr;
+                See the source &rarr;
             </a>
         </div>
 
-        <p class="lesson-promo-note">From our friends at ClaudeKit. One-time purchase, lifetime updates.</p>
+        <p class="lesson-promo-note">From the same team that built this course.</p>
     </div>
 )}
 

--- a/src/components/LessonSidebar.astro
+++ b/src/components/LessonSidebar.astro
@@ -1,0 +1,333 @@
+---
+// Sticky lesson sidebar: groups all lessons by module, highlights current lesson,
+// shows overall progress count. Desktop = sticky column; mobile = off-canvas drawer.
+import { getCollection } from 'astro:content';
+
+interface Props {
+  currentEntryId: string;
+}
+
+const { currentEntryId } = Astro.props;
+
+const moduleNames: Record<number, string> = {
+  0: 'Getting Started',
+  1: 'Core Concepts',
+  2: 'Advanced Applications',
+  3: 'Capstone',
+};
+
+const all = (await getCollection('modules')).sort((a, b) => a.data.order - b.data.order);
+
+function lessonHref(e: typeof all[number]) {
+  const tail = e.id.split('/').pop()?.replace('.mdx', '').split('-').slice(1).join('-');
+  return `/modules/${e.data.module}/${tail}/`;
+}
+
+// Group entries by module number, preserving sort order.
+const grouped = new Map<number, typeof all>();
+for (const e of all) {
+  const arr = grouped.get(e.data.module) ?? [];
+  arr.push(e);
+  grouped.set(e.data.module, arr);
+}
+
+const currentIndex = all.findIndex((e) => e.id === currentEntryId);
+const totalLessons = all.length;
+const currentNumber = currentIndex + 1; // 1-based for display
+const currentEntry = all[currentIndex];
+const currentModule = currentEntry?.data.module ?? 0;
+---
+
+<button
+  id="lesson-sidebar-toggle"
+  class="lesson-sidebar-fab"
+  type="button"
+  aria-label="Open lessons navigation"
+  aria-expanded="false"
+  aria-controls="lesson-sidebar"
+>
+  <span class="fab-count">{currentNumber}/{totalLessons}</span>
+  <span class="fab-label">Lessons</span>
+</button>
+
+<div id="lesson-sidebar-scrim" class="lesson-sidebar-scrim" hidden></div>
+
+<aside
+  id="lesson-sidebar"
+  class="lesson-sidebar"
+  aria-label="All lessons"
+>
+  <div class="sidebar-header">
+    <p class="sidebar-eyebrow">Course progress</p>
+    <p class="sidebar-progress">
+      <span class="progress-current">Lesson {currentNumber}</span>
+      <span class="progress-divider">of</span>
+      <span class="progress-total">{totalLessons}</span>
+    </p>
+    <div class="progress-bar" aria-hidden="true">
+      <div class="progress-fill" style={`width: ${(currentNumber / totalLessons) * 100}%`}></div>
+    </div>
+    <button
+      type="button"
+      id="lesson-sidebar-close"
+      class="sidebar-close"
+      aria-label="Close lessons navigation"
+    >×</button>
+  </div>
+
+  <nav class="sidebar-modules" aria-label="Modules and lessons">
+    {[...grouped.entries()].map(([modNum, entries]) => (
+      <section class={`sidebar-module ${modNum === currentModule ? 'is-current' : ''}`}>
+        <h3 class="sidebar-module-title">
+          <span class="sidebar-module-num">M{modNum}</span>
+          <span class="sidebar-module-name">{moduleNames[modNum] ?? `Module ${modNum}`}</span>
+        </h3>
+        <ol class="sidebar-lessons">
+          {entries.map((e) => (
+            <li class={`sidebar-lesson ${e.id === currentEntryId ? 'is-active' : ''}`}>
+              <a href={lessonHref(e)} aria-current={e.id === currentEntryId ? 'page' : undefined}>
+                <span class="lesson-num">{e.data.module}.{e.data.lesson}</span>
+                <span class="lesson-title">{e.data.title}</span>
+              </a>
+            </li>
+          ))}
+        </ol>
+      </section>
+    ))}
+  </nav>
+
+  <a href="/modules/" class="sidebar-hub-link">All modules →</a>
+</aside>
+
+<script>
+  // Mobile drawer toggle (mirrors Header.astro mobile-drawer pattern).
+  const sidebar = document.getElementById('lesson-sidebar');
+  const fab = document.getElementById('lesson-sidebar-toggle');
+  const scrim = document.getElementById('lesson-sidebar-scrim');
+  const closeBtn = document.getElementById('lesson-sidebar-close');
+
+  function open() {
+    sidebar?.classList.add('is-open');
+    scrim?.removeAttribute('hidden');
+    fab?.setAttribute('aria-expanded', 'true');
+    document.body.style.overflow = 'hidden';
+  }
+  function close() {
+    sidebar?.classList.remove('is-open');
+    scrim?.setAttribute('hidden', '');
+    fab?.setAttribute('aria-expanded', 'false');
+    document.body.style.overflow = '';
+  }
+
+  fab?.addEventListener('click', () => {
+    sidebar?.classList.contains('is-open') ? close() : open();
+  });
+  scrim?.addEventListener('click', close);
+  closeBtn?.addEventListener('click', close);
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && sidebar?.classList.contains('is-open')) close();
+  });
+
+  // Scroll the active lesson into view inside the sidebar on load.
+  const active = sidebar?.querySelector('.sidebar-lesson.is-active');
+  active?.scrollIntoView({ block: 'center' });
+</script>
+
+<style>
+  /* === Desktop sticky sidebar === */
+  .lesson-sidebar {
+    position: sticky;
+    top: 100px; /* clears the fixed header */
+    align-self: start;
+    width: 260px;
+    max-height: calc(100vh - 120px);
+    overflow-y: auto;
+    background: var(--bg-secondary);
+    border: 3px solid var(--border-color);
+    box-shadow: 6px 6px 0 var(--mustard);
+    padding: 20px;
+    font-size: 0.92em;
+  }
+
+  .sidebar-header {
+    position: relative;
+    padding-bottom: 16px;
+    margin-bottom: 16px;
+    border-bottom: 2px solid var(--border-color);
+  }
+
+  .sidebar-eyebrow {
+    text-transform: uppercase;
+    font-size: 0.7em;
+    letter-spacing: 0.1em;
+    color: var(--text-secondary);
+    margin: 0 0 6px;
+  }
+
+  .sidebar-progress {
+    margin: 0 0 10px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+  .progress-current { color: var(--rust); }
+  .progress-divider { opacity: 0.5; margin: 0 4px; }
+
+  .progress-bar {
+    height: 6px;
+    background: var(--cream);
+    border: 1px solid var(--border-color);
+    overflow: hidden;
+  }
+  .progress-fill {
+    height: 100%;
+    background: var(--rust);
+    transition: width 0.3s ease;
+  }
+
+  .sidebar-close {
+    display: none; /* mobile only */
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    width: 32px;
+    height: 32px;
+    border: 2px solid var(--border-color);
+    background: var(--bg-primary);
+    font-size: 1.4em;
+    line-height: 1;
+    cursor: pointer;
+    color: var(--text-primary);
+  }
+
+  .sidebar-modules {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+  }
+
+  .sidebar-module-title {
+    font-family: var(--font-display);
+    font-size: 0.95em;
+    margin: 0 0 8px;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    color: var(--text-primary);
+  }
+  .sidebar-module-num {
+    background: var(--plum);
+    color: white;
+    padding: 2px 6px;
+    font-size: 0.75em;
+    font-weight: 600;
+  }
+  .sidebar-module.is-current .sidebar-module-num {
+    background: var(--rust);
+  }
+
+  .sidebar-lessons {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    border-left: 2px solid var(--border-color);
+  }
+
+  .sidebar-lesson a {
+    display: flex;
+    gap: 8px;
+    padding: 6px 10px;
+    color: var(--text-secondary);
+    text-decoration: none;
+    border-left: 3px solid transparent;
+    margin-left: -2px;
+    line-height: 1.35;
+  }
+  .sidebar-lesson a:hover {
+    color: var(--text-primary);
+    background: var(--bg-primary);
+  }
+  .sidebar-lesson.is-active a {
+    color: var(--text-primary);
+    border-left-color: var(--rust);
+    font-weight: 600;
+    background: rgba(184, 92, 60, 0.08);
+  }
+
+  .lesson-num {
+    flex-shrink: 0;
+    font-family: 'Fira Code', monospace;
+    font-size: 0.85em;
+    opacity: 0.7;
+    min-width: 28px;
+  }
+  .lesson-title {
+    font-size: 0.92em;
+  }
+
+  .sidebar-hub-link {
+    display: block;
+    margin-top: 20px;
+    padding-top: 16px;
+    border-top: 2px solid var(--border-color);
+    color: var(--rust);
+    text-decoration: none;
+    font-weight: 600;
+    text-align: center;
+  }
+  .sidebar-hub-link:hover { color: var(--mustard); }
+
+  /* === Mobile floating button === */
+  .lesson-sidebar-fab {
+    display: none; /* hidden on desktop, shown via @media below */
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    z-index: 90;
+    padding: 12px 18px;
+    background: var(--rust);
+    color: white;
+    border: 3px solid var(--charcoal);
+    box-shadow: 4px 4px 0 var(--mustard);
+    cursor: pointer;
+    font-weight: 600;
+    align-items: center;
+    gap: 8px;
+    font-family: inherit;
+  }
+  .fab-count {
+    font-family: 'Fira Code', monospace;
+    font-size: 0.9em;
+    opacity: 0.9;
+  }
+  .fab-label { font-size: 0.95em; }
+
+  .lesson-sidebar-scrim {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 100;
+  }
+
+  /* === Mobile drawer mode === */
+  @media (max-width: 1024px) {
+    .lesson-sidebar-fab { display: inline-flex; }
+
+    .lesson-sidebar {
+      position: fixed;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      width: min(320px, 85vw);
+      max-height: 100vh;
+      z-index: 110;
+      transform: translateX(100%);
+      transition: transform 0.25s ease;
+      box-shadow: -6px 0 12px rgba(0, 0, 0, 0.15);
+      border-right: none;
+    }
+    .lesson-sidebar.is-open {
+      transform: translateX(0);
+    }
+    .sidebar-close { display: block; }
+  }
+</style>

--- a/src/config/promo.ts
+++ b/src/config/promo.ts
@@ -7,10 +7,10 @@ export const promoConfig = {
     // Hello Bar (top banner)
     helloBar: {
         enabled: true,
-        text: "New post: Introducing Threadmark — bring threads into your AI workflow",
-        linkText: "Read now",
-        linkUrl: "https://cc4.marketing/blog/introducing-threadmark/",
-        storageKey: "hellobar-introducing-threadmark",
+        text: "New capstone — Module 3: Ship a Real Follow-Up with sigil",
+        linkText: "Start lesson",
+        linkUrl: "https://cc4.marketing/modules/3/ship-with-sigil/",
+        storageKey: "hellobar-m3-sigil-capstone",
         cooldownDays: 3
     },
 
@@ -27,9 +27,9 @@ export const promoConfig = {
     // Lesson Promo Banner (floating inside course lessons)
     lessonBanner: {
         enabled: true,
-        storageKey: "lesson-promo-claudekit-v130",
+        storageKey: "lesson-promo-m3-sigil-capstone",
         cooldownDays: 3,
-        linkUrl: "https://claudekit.cc/?ref=BIZE9CYY",
-        releaseNotesUrl: "https://claudekit.cc/updates/claudekit-marketing/v1-3-0-the-biggest-update-yet?ref=BIZE9CYY"
+        linkUrl: "https://cc4.marketing/modules/3/ship-with-sigil/",
+        releaseNotesUrl: "https://github.com/blacklogos/sigil"
     }
 };

--- a/src/config/siteData.ts
+++ b/src/config/siteData.ts
@@ -53,6 +53,14 @@ export const siteData = {
         lessons: ['Campaign Briefs', 'Content Strategy', 'Marketing Copy', '+ 3 more lessons'],
         href: '/modules/2/campaign-brief/'
       },
+      {
+        number: 3,
+        title: 'Capstone',
+        description: 'Ship a real personalized follow-up campaign end-to-end with sigil, an open-source CLI inside Claude Code.',
+        lessonCount: '1 Lesson • 75 minutes',
+        lessons: ['Ship a Real Follow-Up with sigil'],
+        href: '/modules/3/ship-with-sigil/'
+      },
     ],
     stats: [
       { number: '10x', label: 'Campaign Speed' },

--- a/src/content/modules/module-0/0.0-introduction.mdx
+++ b/src/content/modules/module-0/0.0-introduction.mdx
@@ -51,7 +51,7 @@ By the end of this course, you'll be able to:
 
 ## How Is the Course Structured?
 
-This course is divided into three modules:
+This course is divided into four modules:
 
 ### Module 0: Getting Started (30 minutes)
 You'll install Claude Code and set up your workspace. By the end, you'll be ready to start using Claude Code for marketing.
@@ -61,6 +61,9 @@ Learn the fundamentals of Claude Code with marketing-specific examples. You'll m
 
 ### Module 2: Advanced Applications (4-5 hours)
 Apply everything you've learned to real marketing challenges: campaign briefs, content strategy, analytics, and more.
+
+### Module 3: Capstone (75 minutes)
+Ship a real personalized post-event follow-up campaign end-to-end with [sigil](https://github.com/blacklogos/sigil) — an open-source CLI that lives inside Claude Code. One handcrafted sentence per recipient, real send to your inbox first.
 
 ## The Compounding Effect
 

--- a/src/content/modules/module-3/3.1-ship-with-sigil.mdx
+++ b/src/content/modules/module-3/3.1-ship-with-sigil.mdx
@@ -1,0 +1,222 @@
+---
+title: "Ship a Real Follow-Up with sigil"
+module: 3
+lesson: 1
+description: "Capstone — apply Modules 0–2 to send personalized post-event follow-up emails using sigil, an open-source CLI that lives inside Claude Code. One handcrafted sentence per recipient, signed PDF links, real send to your inbox first."
+duration: "75 min"
+objectives:
+  - Bootstrap a real campaign workspace with `sig init`
+  - Ingest attendee data from Google Forms or Sheets
+  - Use a custom Claude Code slash command (`/email-rewrite`) to handcraft per-row sentences
+  - Send a verified test campaign, then a real one (with a built-in confirm gate)
+  - Read click-rates via `sig status` and reason about what they mean
+  - Explain why this is a CLI + slash command, not a SaaS dashboard
+order: 18
+---
+
+## Why a Capstone, and Why This One?
+
+You've spent the last three modules learning to partner with Claude on briefs, content, analytics, competitive analysis, and SEO. This capstone makes one of those skills **land in someone's inbox** — the post-event follow-up that every Planerio campaign needs but nobody quite wants to write 30 times.
+
+You'll use **[sigil](https://github.com/blacklogos/sigil)** — a small open-source CLI built as the companion artifact to this course. It speaks the same agent-loop philosophy Module 1 introduced: a custom AI agent (`/email-rewrite`) handcrafts one sentence per recipient, while a real CLI handles the boring parts (tokens, tracking, deliverability).
+
+> **Heads up — prerequisites matter for this one.** You'll need a terminal, a Cloudflare account, and ~75 minutes. If that's a stretch right now, skim the lesson and bookmark it for when you have an event to send for real. There's also a done-with-you setup offer linked at the end if you'd rather pair on it once.
+
+### What You'll Learn
+
+- How to take a real attendee list to a sent campaign in under 90 minutes
+- How a custom slash command (built in Module 1 style) integrates with a real tool
+- How to test a campaign with confidence before clicking "send" on a real list
+- Why click-rate on a per-recipient link is more honest signal than open-rate
+
+### What You'll Build
+
+A working campaign for Planerio's most recent CMO Roundtable — 30 attendees, one PDF deck, personalized follow-ups in your sender's voice — that lands in **your own inbox** first as a test, then goes for real on your timing.
+
+## Prerequisites Check
+
+Before you start, make sure you have:
+
+- ✅ Completed Modules 1 and 2 (Claude Code basics + marketing workflows)
+- ✅ Claude Code installed and working
+- ✅ Comfort in a terminal: clone a repo, run `npm install`, edit a file
+- ✅ A Cloudflare account (free tier works; Email Service requires Workers Paid `$5/mo` only when sending to unverified destinations — first 1,000/day are included)
+- ✅ A sender email on a domain you control with SPF/DKIM/DMARC set up (Cloudflare Email Routing makes this a 5-minute setup if you haven't done it yet)
+- ✅ A short PDF to attach (e.g., the Planerio CMO Roundtable deck — under 5MB)
+
+If any of those is missing, pause here. Set them up, then come back.
+
+## The Scenario
+
+Planerio just hosted a **CMO Roundtable** for 30 invited operators. The deck is exported. The Google Form RSVP turned into a Sheets export of 30 rows with name + email + role + a free-text field where attendees noted what they wanted to dig into.
+
+Your job in the next 75 minutes: send each of those 30 attendees a follow-up email with the deck and **one sentence written specifically for them** — referencing the thing they said they wanted to dig into. No mailmerge tags. No `"Dear {firstname}."` A real sentence per row.
+
+Bulk-email tools (Mailchimp, HubSpot) force you into segments and merge fields. We're going to do the opposite: one CLI, one slash command, 30 handcrafted sentences, one send.
+
+## How to Ship the Campaign: Step-by-Step
+
+### Step 1 — Install sigil (5 min)
+
+```bash
+git clone https://github.com/blacklogos/sigil ~/Documents/sigil
+cd ~/Documents/sigil && npm install && npm link
+sig --version    # should print a version like 0.1.0
+sig --help       # tour the subcommands
+```
+
+`sig` is now on your `PATH`. It can be run from any campaign workspace.
+
+### Step 2 — Onboard a campaign workspace (8 min)
+
+```bash
+mkdir ~/Documents/planerio-cmo-roundtable && cd $_
+sig init
+```
+
+`sig init` is an interactive TUI. Fill in the fields:
+
+- **`CF_API_TOKEN`** — Cloudflare API token with scopes: `Email Sending: Edit/Read`, `Workers KV: Read`, `Workers Scripts: Edit`, `R2: Edit`
+- **`CF_ACCOUNT_ID`** — from your Cloudflare dashboard
+- **`FROM_EMAIL`** — `partner@planerio.com` (or your verified sender)
+- **`FROM_NAME`** — `Planerio Team`
+- **`EVENT_NAME`** — `Planerio CMO Roundtable`
+- **`EVENT_DAY_PHRASE`** — `last Thursday` (anything that flows after "đến / came to \<event\> …")
+- **`EMAIL_SUBJECT`** — `Slides from yesterday's roundtable + a thought for you`
+- **`PDF_BASE_URL`** — the URL of your Cloudflare Worker that serves the PDF (e.g., `https://pdf.planerio.com`)
+- **`TEST_EMAILS`** — your own inbox (we'll send the test there first)
+- **agents to install** — `claude` (drops the `/email-rewrite` slash command into your workspace)
+
+> **Scriptable variant.** If you'd rather not click through the TUI, pass every field as a flag: `sig init --non-interactive --cf-api-token="…" --event-name="…" …`. This is the agent-friendly path — same audience the rest of the course has been teaching you to design for.
+
+### Step 3 — Deploy the PDF worker (10 min)
+
+```bash
+cp ~/Documents/sigil/worker/wrangler.example.toml worker/wrangler.toml
+# edit: worker name (e.g. planerio-pdf), R2 bucket binding, KV namespace
+wrangler r2 object put <bucket>/planerio-cmo-deck.pdf --file=./deck.pdf --remote
+cd worker && npx wrangler deploy && cd ..
+```
+
+The Worker's job is small: when someone clicks their personal PDF link (`https://pdf.planerio.com/p/<token>`), it logs the click to KV and streams the PDF from R2. You don't have to touch the Worker code — it's already in the repo.
+
+### Step 4 — Ingest the leads (5 min)
+
+Two paths. Pick one.
+
+```bash
+# Path A: CSV from Google Forms or Sheets
+cp ./roundtable-export.csv data/leads.csv
+sig ingest
+
+# Path B: pipe directly from Google Workspace via gog
+gog sheets get <SHEET_ID> 'A1:Z' --plain | sig ingest --stdin
+```
+
+Headers are slugified automatically: `Tên đầy đủ` → `full_name`, `What do you want to dig into?` → `what_do_you_want_to_dig_into`, etc. Anything that isn't a known typed field (email, name, tone) lands in `lead.extras` and is addressable in the template as `{{slug}}`.
+
+### Step 5 — Review the state (5 min)
+
+```bash
+sig review --table       # compact view of all 30 rows
+sig review --diff        # diff vs last send (empty on first run)
+sig preview --all        # render every email; warns on unresolved {{var}}
+```
+
+This is your dry run. The `--json` flag is also available if you want to pipe `sig review --json` into `jq` or another tool — the CLI was designed for both you and an agent to consume.
+
+### Step 6 — Handcraft sentences with `/email-rewrite` (15 min)
+
+This is the **agent-in-the-loop moment** — the lesson Module 1 has been building toward.
+
+```bash
+sig prompt
+# walk each row. For tricky ones, type ?<one-line hint>
+#   e.g. ?reference their question about onboarding latency
+# For obvious ones, type /default
+```
+
+Now switch to Claude Code chat and run:
+
+```
+/email-rewrite
+```
+
+The slash command (a tiny shim file dropped by `sig init`) reads the queue and walks you through each one. For every row Claude proposes a sentence, shows you a diff against the current one, and asks: **keep / regenerate / edit verbatim / skip**.
+
+Notice the shape of this interaction:
+
+- **You** brought the strategic input (the hint, the brand voice, the tone)
+- **Claude** structured and articulated it
+- **Sigil** is the tool that holds state and ensures nothing accidentally gets sent
+
+This is the same collaborative pattern Module 2's campaign-brief lesson taught — applied to a fundamentally different artifact.
+
+### Step 7 — Mint tokens + deploy (5 min)
+
+```bash
+sig prep
+cd worker && npx wrangler deploy && cd ..
+```
+
+`sig prep` writes a unique signed token for every recipient and updates `wrangler.toml` so the Worker recognizes them. Re-deploying the Worker pushes the new token set live.
+
+### Step 8 — Test send (10 min)
+
+```bash
+sig send --test
+```
+
+Because `TEST_EMAILS` is set in your `.env`, this rewrites every `To:` to your own inbox. All 30 personalized copies land in front of you. Click 3 PDF links to confirm the Worker streams the right file. Read 5 of the sentences end-to-end — would each recipient actually feel addressed?
+
+> **Stop here if anything looks off.** Fix sentences with `/email-rewrite` again. The test-send loop is the safety net before the real send.
+
+### Step 9 — Real send (5 min)
+
+```bash
+sig send
+```
+
+Sigil prints a summary — *"About to send 30 live email(s) (alice@example.com … omar@example.com). Continue? [y/N]"* — and waits for you. Press `y` to ship.
+
+For the **scripted variant** (CI, agent, batch), use `sig send --yes`. Same conventions Module 1 introduced for "custom AI agents for marketing tasks": every destructive operation has an explicit opt-in flag that distinguishes a human "I meant it" from an agent's `--yes`.
+
+### Step 10 — Read the results (5 min)
+
+```bash
+sig status               # human-friendly table
+sig status --json | jq   # for scripting / dashboards
+```
+
+You'll see, per recipient: did they click the PDF link, when was the first click, how many clicks total. There's intentionally no email open-pixel (we don't want to be that company); click-rate on a per-recipient signed link is the honest metric.
+
+## Reflection — 5 Minutes Before You Close This Tab
+
+- Where did `/email-rewrite` save you time vs. writing each sentence by hand? Where did it cost time?
+- If you ran this same workflow on 200 recipients instead of 30, what would break first? *(Hint: technically nothing until Cloudflare's 1,000/day quota; but practically, you can't handcraft 200 sentences in a single sitting. That's why sigil is positioned for VIP-size sends, ≤50. The constraint is intentional.)*
+- Which CLI conventions (`--json`, `--yes`, exit codes, `--no-input`) from this lesson would you want in your **own** custom marketing tools? Module 1's "build custom agents" thread runs straight through here.
+- When does this approach lose to Lemlist / HubSpot? When does it win? *(Loses on bulk + reporting; wins on per-recipient handcrafted voice + ownership of the data + agent-loop integration.)*
+
+## Stretch Goals (Optional)
+
+Pick one if you have time:
+
+1. **English-language template** — set `BODY_TEMPLATE=templates/body.en.md` in `.env` and re-run preview. Sigil ships an English example body alongside the default Vietnamese one.
+2. **Run `/email-rewrite` from a different agent** — install the Antigravity shim (`sig init --agents=claude,antigravity`) and try the same flow in Antigravity. Notice what changes and what doesn't.
+3. **Your own voice** — fork `templates/body.md` and rewrite the body shell in your own tone. Pin it via `BODY_TEMPLATE` in `.env`. Re-run preview and see how much character you can get into a follow-up.
+
+## When You're Stuck
+
+Two paths:
+
+- **Read** sigil's [AGENTS.md](https://github.com/blacklogos/sigil/blob/main/AGENTS.md) and [docs/howto.md](https://github.com/blacklogos/sigil/blob/main/docs/howto.md) — written for agents, useful for humans.
+- **Reach out** — the sigil author offers a [done-with-you setup](https://mtri.me) if you'd rather pair on the first campaign. Same audience this course is for, same person who wrote the tool.
+
+## Key Takeaways
+
+- **Custom AI agents make sense when they sit on top of a real tool with real state.** `/email-rewrite` works because sigil owns the `leads.json` state and the deliverability mechanics. The agent's job is the one part only a human-LLM partnership can do well: the per-row sentence.
+- **CLIs that are predictable for humans are automatically callable by agents.** The same `--json`, `--yes`, exit-code-discipline that made sigil pleasant to use at your terminal also lets a future automation drive it without modification.
+- **Bulk-email tools optimize for the wrong thing for VIP-size sends.** When N ≤ 50 and craft matters more than throughput, a CLI + slash command beats a SaaS dashboard.
+- **Click-rate is honest signal. Open-rate isn't.** Choose the metric that reflects intent, not the one that's easy to inflate with a tracking pixel.
+
+> **Course Bonus Complete.** You've shipped a real marketing artifact end-to-end using the agent-loop pattern this course has been building toward. Everything else from here is taste — your tone, your audience, your moments worth sending.

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import HelloBar from '../components/HelloBar.astro';
 import FloatingSideBanner from '../components/FloatingSideBanner.astro';
 import CodeBlockCopy from '../components/CodeBlockCopy.astro';
+import GoogleAnalytics from '../components/GoogleAnalytics.astro';
 import { promoConfig } from '../config/promo';
 import { resolveOgImage, type OgPageKey, type OgPostInput } from '../lib/og/url';
 
@@ -135,6 +136,7 @@ const breadcrumbSchema = {
   
   <!-- Analytics -->
   <script src="https://beamanalytics.b-cdn.net/beam.min.js" data-token="a46f220a-19be-4dec-b14f-c91818639a8d" async></script>
+  <GoogleAnalytics />
   
   <!-- Primary Meta Tags -->
   <title>{fullTitle}</title>

--- a/src/layouts/LessonLayout.astro
+++ b/src/layouts/LessonLayout.astro
@@ -5,6 +5,7 @@ import Footer from '../components/Footer.astro';
 import FeedbackButton from '../components/FeedbackButton.astro';
 import ModuleUpdatesBanner from '../components/ModuleUpdatesBanner.astro';
 import LessonPromoBanner from '../components/LessonPromoBanner.astro';
+import LessonSidebar from '../components/LessonSidebar.astro';
 import { promoConfig } from '../config/promo';
 
 interface Props {
@@ -15,14 +16,16 @@ interface Props {
   duration?: string;
   prevLesson?: { title: string; href: string };
   nextLesson?: { title: string; href: string };
+  currentEntryId: string;
 }
 
-const { title, module, lesson, description, duration, prevLesson, nextLesson } = Astro.props;
+const { title, module, lesson, description, duration, prevLesson, nextLesson, currentEntryId } = Astro.props;
 
 const moduleNames: Record<number, string> = {
   0: 'Getting Started',
   1: 'Core Concepts',
   2: 'Advanced Applications',
+  3: 'Capstone',
 };
 const moduleName = moduleNames[module] ?? `Module ${module}`;
 const moduleUrl = `https://cc4.marketing/modules/${module}/`;
@@ -43,6 +46,7 @@ const breadcrumbSchema = {
   <Header />
   
   <main class="lesson-container">
+    <LessonSidebar currentEntryId={currentEntryId} />
     <div class="lesson-content">
       <div class="lesson-header">
         <div class="lesson-meta">
@@ -88,16 +92,21 @@ const breadcrumbSchema = {
     padding: 120px 24px 60px;
     min-height: 100vh;
     background: var(--bg-primary);
+    /* Two-column layout on desktop: sidebar + content, centered as a pair. */
+    display: grid;
+    grid-template-columns: 260px minmax(0, 800px);
+    gap: 32px;
+    justify-content: center;
+    align-items: start;
   }
 
   .lesson-content {
-    max-width: 800px;
-    margin: 0 auto;
     background: var(--bg-secondary);
     padding: 60px;
     border: 3px solid var(--border-color);
     box-shadow: 12px 12px 0 var(--mustard);
     color: var(--text-primary);
+    min-width: 0; /* allow grid item to shrink below content size */
   }
 
   .lesson-header {
@@ -269,6 +278,13 @@ const breadcrumbSchema = {
     display: block;
     color: var(--text-primary);
     font-weight: 600;
+  }
+
+  /* Mobile / narrow: collapse to single column; sidebar becomes the drawer FAB. */
+  @media (max-width: 1024px) {
+    .lesson-container {
+      grid-template-columns: minmax(0, 800px);
+    }
   }
 
   @media (max-width: 768px) {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -146,9 +146,9 @@ import WhatsNew from '../components/WhatsNew.astro';
   <section class="modules-section" id="modules">
     <div class="container">
       <div class="section-header">
-        <div class="section-label">Three Modules</div>
+        <div class="section-label">Four Modules</div>
         <h2 class="section-title">Your Learning Path</h2>
-        <p class="section-description">Master AI-powered marketing in 2 weeks. Three modules. 17 lessons. Real transformations.</p>
+        <p class="section-description">Master AI-powered marketing in 2 weeks. Four modules. 18 lessons. Real transformations.</p>
       </div>
 
       <div class="modules-grid">

--- a/src/pages/modules/[...slug].astro
+++ b/src/pages/modules/[...slug].astro
@@ -39,6 +39,7 @@ const { Content } = await render(entry);
   duration={entry.data.duration}
   prevLesson={prevLesson}
   nextLesson={nextLesson}
+  currentEntryId={entry.id}
 >
   <Content />
 </LessonLayout>

--- a/src/pages/modules/index.astro
+++ b/src/pages/modules/index.astro
@@ -1,0 +1,231 @@
+---
+// Modules hub — lists all modules + lessons. Reads from the content collection
+// so adding a lesson is one file edit; no separate config to update.
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+
+const moduleNames: Record<number, string> = {
+  0: 'Getting Started',
+  1: 'Core Concepts',
+  2: 'Advanced Applications',
+  3: 'Capstone',
+};
+
+const moduleBlurbs: Record<number, string> = {
+  0: 'Install Claude Code and set up your workspace.',
+  1: 'Master files, agents, automation, and project memory.',
+  2: 'Apply Claude Code to real Planerio campaigns end-to-end.',
+  3: 'Ship a real personalized follow-up campaign with sigil.',
+};
+
+const all = (await getCollection('modules')).sort((a, b) => a.data.order - b.data.order);
+
+function lessonHref(e: typeof all[number]) {
+  const tail = e.id.split('/').pop()?.replace('.mdx', '').split('-').slice(1).join('-');
+  return `/modules/${e.data.module}/${tail}/`;
+}
+
+// Group lessons by module, preserve order.
+const grouped = new Map<number, typeof all>();
+for (const e of all) {
+  const arr = grouped.get(e.data.module) ?? [];
+  arr.push(e);
+  grouped.set(e.data.module, arr);
+}
+
+const totalLessons = all.length;
+const totalModules = grouped.size;
+---
+
+<BaseLayout
+  title="All Modules"
+  description={`The full CC4.Marketing curriculum — ${totalModules} modules, ${totalLessons} lessons. Master Claude Code for marketers from install to a real shipped campaign.`}
+>
+  <Header />
+
+  <main class="modules-hub">
+    <header class="hub-header">
+      <p class="hub-eyebrow">Curriculum</p>
+      <h1>All Modules</h1>
+      <p class="hub-lede">
+        {totalModules} modules · {totalLessons} lessons · install to shipped campaign.
+      </p>
+    </header>
+
+    <section class="modules-list">
+      {[...grouped.entries()].map(([modNum, entries]) => (
+        <article class="module-block">
+          <header class="module-head">
+            <div class="module-tag">Module {modNum}</div>
+            <h2>{moduleNames[modNum] ?? `Module ${modNum}`}</h2>
+            <p class="module-blurb">{moduleBlurbs[modNum] ?? ''}</p>
+            <p class="module-meta">{entries.length} {entries.length === 1 ? 'lesson' : 'lessons'}</p>
+          </header>
+
+          <ol class="lesson-list">
+            {entries.map((e) => (
+              <li>
+                <a href={lessonHref(e)} class="lesson-link">
+                  <span class="lesson-num">{e.data.module}.{e.data.lesson}</span>
+                  <span class="lesson-body">
+                    <span class="lesson-title">{e.data.title}</span>
+                    <span class="lesson-desc">{e.data.description}</span>
+                  </span>
+                  {e.data.duration && <span class="lesson-duration">{e.data.duration}</span>}
+                </a>
+              </li>
+            ))}
+          </ol>
+        </article>
+      ))}
+    </section>
+  </main>
+
+  <Footer />
+</BaseLayout>
+
+<style>
+  .modules-hub {
+    padding: 120px 24px 80px;
+    max-width: 960px;
+    margin: 0 auto;
+    color: var(--text-primary);
+  }
+
+  .hub-header {
+    text-align: center;
+    margin-bottom: 60px;
+  }
+  .hub-eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    font-size: 0.75em;
+    font-weight: 700;
+    color: var(--rust);
+    margin: 0 0 12px;
+  }
+  .hub-header h1 {
+    font-family: var(--font-display);
+    font-size: clamp(2.2em, 5vw, 3.4em);
+    margin: 0 0 12px;
+    color: var(--text-primary);
+  }
+  .hub-lede {
+    color: var(--text-secondary);
+    font-size: 1.1em;
+    margin: 0;
+  }
+
+  .modules-list {
+    display: flex;
+    flex-direction: column;
+    gap: 40px;
+  }
+
+  .module-block {
+    background: var(--bg-secondary);
+    border: 3px solid var(--border-color);
+    box-shadow: 8px 8px 0 var(--mustard);
+    padding: 36px;
+  }
+
+  .module-head {
+    border-bottom: 2px solid var(--border-color);
+    padding-bottom: 20px;
+    margin-bottom: 24px;
+  }
+  .module-tag {
+    display: inline-block;
+    background: var(--plum);
+    color: white;
+    padding: 4px 12px;
+    font-size: 0.8em;
+    font-weight: 600;
+    margin-bottom: 10px;
+  }
+  .module-head h2 {
+    font-family: var(--font-display);
+    font-size: 1.8em;
+    margin: 0 0 8px;
+    color: var(--text-primary);
+  }
+  .module-blurb {
+    color: var(--text-secondary);
+    margin: 0 0 8px;
+    font-size: 1em;
+  }
+  .module-meta {
+    color: var(--text-secondary);
+    font-size: 0.85em;
+    margin: 0;
+    opacity: 0.7;
+  }
+
+  .lesson-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .lesson-link {
+    display: grid;
+    grid-template-columns: 50px 1fr auto;
+    gap: 16px;
+    align-items: start;
+    padding: 14px 16px;
+    border: 2px solid var(--border-color);
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    text-decoration: none;
+    transition: all 0.2s ease;
+  }
+  .lesson-link:hover {
+    transform: translate(-3px, -3px);
+    box-shadow: 4px 4px 0 var(--rust);
+    border-color: var(--rust);
+  }
+  .lesson-num {
+    font-family: 'Fira Code', monospace;
+    font-weight: 700;
+    color: var(--rust);
+  }
+  .lesson-body {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+  }
+  .lesson-title {
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+  .lesson-desc {
+    font-size: 0.9em;
+    color: var(--text-secondary);
+    line-height: 1.45;
+  }
+  .lesson-duration {
+    font-size: 0.8em;
+    color: var(--text-secondary);
+    opacity: 0.7;
+    white-space: nowrap;
+    padding-top: 2px;
+  }
+
+  @media (max-width: 640px) {
+    .modules-hub { padding: 100px 16px 60px; }
+    .module-block { padding: 24px; }
+    .lesson-link {
+      grid-template-columns: 40px 1fr;
+    }
+    .lesson-duration {
+      grid-column: 2;
+      padding-top: 4px;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary

Five-commit bundle that lands the sigil capstone end-to-end:

- **`feat(course): add Module 3 capstone — Ship with sigil`** — full 75-min capstone lesson at `src/content/modules/module-3/3.1-ship-with-sigil.mdx`. Home page now lists four modules / 18 lessons (was three / 17). Companion integration plan committed.
- **`feat(course): lesson sidebar + /modules/ hub`** — sticky desktop sidebar (current lesson highlighted, progress bar, jump-to-any-lesson); mobile drawer via FAB. New `/modules/` hub lists every module + lesson (previously 404).
- **`chore(promo): point hello bar + lesson banner at the M3 capstone`** — both promos drive traffic to the new lesson. Storage keys bumped so prior dismissals don't suppress them.
- **`feat(analytics): add Google Analytics 4 alongside Beam`** — production-only gtag, env-driven (`PUBLIC_GA_MEASUREMENT_ID`). Beam keeps running unchanged.
- **`docs(solutions): MDX silent empty-prose on unescaped {curly-braces}`** — bug-track learning + AGENTS.md pointer so future authors don't lose an afternoon to the same silent failure.

## Why

PR #22 shipped the author homepages. This PR closes out the rest of the session:
1. **Capstone lesson** — the cc4 ↔ sigil integration plan called for one lesson; this lands it.
2. **Navigation** — mid-page learners had no way to see position/progress or jump elsewhere. Sidebar + hub fix that.
3. **Promos** — surface the new capstone to course traffic.
4. **GA4** — add a second analytics signal next to Beam (both can run; useful for cross-checking).
5. **Learning doc** — captures the MDX `{firstname}` failure mode encountered authoring the lesson so it's a 30-second future fix instead of a 30-minute debug.

## Cloudflare prod env (required for GA4 to fire)

In **Workers & Pages → cc4-mkt → Settings → Variables and Secrets → Build variables**, add:

| Variable | Value | Environment |
|---|---|---|
| `PUBLIC_GA_MEASUREMENT_ID` | `G-RERRE2NHVP` | Production |

`PUBLIC_*` vars are inlined at build time, so this must be a **build** var, not a runtime one. The component is gated on `import.meta.env.PROD && id.startsWith('G-')`, so dev/preview builds without the var simply render no script.

## Test plan

- [ ] `/modules/` returns 200 and lists all four modules with M3 capstone visible
- [ ] `/modules/3/ship-with-sigil/` returns 200 with full prose body (52+ `<p>`/`<h2>`/`<h3>` elements)
- [ ] Lesson sidebar shows current lesson highlighted on a desktop lesson page
- [ ] Mobile lesson page (≤1024px) shows FAB; tapping opens drawer; closing scrim/Esc closes drawer
- [ ] Hello bar text reads "New capstone — Module 3: Ship a Real Follow-Up with sigil"
- [ ] Lesson promo banner badge reads "NEW CAPSTONE"; CTA links to M3 lesson
- [ ] After CF build with `PUBLIC_GA_MEASUREMENT_ID` set: production HTML contains `googletagmanager.com/gtag` and `G-RERRE2NHVP`; GA4 → Realtime shows traffic
- [ ] Preview deploy (no env var): no `gtag` in rendered HTML

## Related

- Plan (cc4-side): `docs/plans/2026-05-16-001-feat-sigil-companion-integration-plan.md`
- Plan (sigil-side): `~/Documents/sigil/plans/cc4-marketing-integration.md`
- MDX learning: `docs/solutions/ui-bugs/mdx-curly-braces-silent-empty-prose-astro-20260517.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)