### PR TITLE
feat: Skills gallery (/skills) with stack cart

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -57,6 +57,15 @@ const blogPages = [
   '/blog/introducing-threadmark',
 ].map((p) => `https://cc4.marketing${p}`);
 
+// Known skill URLs (SSR from the `skills` content collection). SSR routes are
+// invisible to the sitemap plugin, so each must be listed here. Keep in sync
+// with src/content/skills/*.md (one entry per non-draft skill + the index).
+const skillPages = [
+  '/skills/',
+  '/skills/naming/',
+  '/skills/brand-voice/',
+].map((p) => `https://cc4.marketing${p}`);
+
 // https://astro.build/config
 export default defineConfig({
   site: 'https://cc4.marketing',
@@ -66,14 +75,16 @@ export default defineConfig({
     react(),
     mdx(),
     sitemap({
-      customPages: [...modulePages, ...blogPages],
+      customPages: [...modulePages, ...blogPages, ...skillPages],
       // Exclude dev-only routes from the sitemap. These are gated behind
       // import.meta.env.DEV (404 in production) and Disallowed in robots.txt;
       // including them in the sitemap sends a contradictory signal to crawlers.
       filter: (page) =>
         !page.includes('/og-preview') &&
         !page.includes('/og/preview') &&
-        !page.includes('/og/debug'),
+        !page.includes('/og/debug') &&
+        // Binary download endpoints are not pages — keep them out of the sitemap.
+        !page.includes('/download.skill'),
       serialize(item) {
         const url = item.url;
         item.lastmod = new Date().toISOString();
@@ -110,6 +121,11 @@ export default defineConfig({
         }
         // Changelog
         else if (url.includes('/changelog')) {
+          item.priority = 0.8;
+          item.changefreq = 'weekly';
+        }
+        // Skills
+        else if (url.includes('/skills')) {
           item.priority = 0.8;
           item.changefreq = 'weekly';
         }

--- a/docs/brainstorms/2026-06-09-skills-gallery-brainstorm.md
+++ b/docs/brainstorms/2026-06-09-skills-gallery-brainstorm.md
@@ -1,0 +1,131 @@
+---
+date: 2026-06-09
+topic: skills-gallery
+---
+
+# Skills gallery (`/skills`) — share CC4 Marketing Claude agent skills
+
+## What we're building
+
+A public `/skills` section on cc4.marketing where CC4 Marketing shares its own
+curated Claude agent skills (SKILL.md bundles — e.g. naming, brand voice,
+content workflows), in the spirit of [kits.vibery.app](https://kits.vibery.app/)
+and the [Anduril naming skill](https://github.com/blacklogos/anduril-naming-skill).
+Positioning is **general CC4M skills** (not marketing-only) — whatever skills the
+team builds, with a curated editorial bar.
+
+**Success looks like:** the gallery is live with 1–3 CC4M skills, each with a
+shareable detail URL, working GitHub link + `.skill` download + inline SKILL.md,
+indexed in the sitemap and `llms.txt`. (Copy-install-command lands in a later
+increment with the marketplace — see below.)
+
+- **Index** `/skills/` — responsive card grid (cloned from `blog/index.astro`):
+  each card shows the skill name, a short description, and tags.
+- **Detail** `/skills/<slug>/` — its own canonical URL for sharing + SEO, with
+  **four ways to get the skill**:
+  1. **Link to the GitHub repo** (the skill's source / README install steps)
+  2. **Copy install command** — a one-click copy of `/plugin marketplace add <cc4m-marketplace>` (+ the install step). ⚠️ **Blocked on a prerequisite:** the CC4M marketplace does not exist yet (see Resolved Q1). This affordance is live only once that marketplace is stood up; the other three ship without it.
+  3. **Download the packaged `.skill` file** (hosted on R2)
+  4. **Read SKILL.md inline** — the skill body rendered on the page so visitors can read/copy without leaving
+
+This is **not** the existing image-prompts brainstorm
+(`docs/brainstorms/2026-05-09-prompts-gallery-brainstorm.md`, `/prompts`) and
+**not** the per-author writing-prompt library (`src/lib/author-prompts.ts`).
+Different content type (agent skills), different route, separate effort.
+
+## Why this approach
+
+**Chosen: Approach B — static repo-file MVP now, migrate to Emdash D1 later.**
+
+- **Ship fast, low risk.** Skills live as repo files/array entries (the pattern
+  already proven in `src/pages/blog/authors.astro` and `src/data/authors.ts`).
+  No D1 schema, no new publish tooling, version-controlled, reviewable in PRs.
+  At a curated <15-entry scale this is the right altitude (YAGNI).
+- **Same UX as the eventual D1 version.** Index grid + detail pages + the four
+  get-affordances are identical whether data comes from a file or D1 — so the
+  later migration is a data-source swap, not a redesign.
+- **Curated, authors-only, no submissions.** CC4M authors the skills; high
+  editorial bar; no auth/moderation/spam surface. Reuses `src/data/authors.ts`
+  for bylines.
+- **Reuse the site's primitives.** `BaseLayout.astro`, `Header`/`Footer`,
+  neobrutalist card tokens in `global.css`, and `CodeBlockCopy.astro`
+  (auto-injected on `<pre>`) for the copy-install-command button — zero new JS.
+- **Zero new authoring tooling in the MVP.** Skills are added by hand-editing
+  repo files (`src/data/skills.ts` + a markdown body) and opening a PR. The
+  `/publish-skill` skill belongs to the deferred D1 phase, **not v1** — do not
+  scope it into the plan.
+
+**Deferred: Approach A — Emdash D1 `skills` collection + `/publish-skill` skill.**
+The intended end state once publishing cadence justifies redeploy-free entries.
+Mirrors `/publish-post` (D1 insert, R2 upload for `.skill` + assets, sitemap
+regen, ship). Migrate when either trigger hits: more than ~15 entries, or
+updates frequent enough that deploy-per-entry slows publishing.
+
+Approach C (live GitHub-sync of SKILL.md) rejected — rate limits + build-time
+GitHub dependency, no payoff at curated scale.
+
+## Key decisions
+
+- **Routes**: `/skills/` (index) and `/skills/<slug>/` (detail). New top-level
+  route, not nested under `/blog/`. Skills aren't blog posts; keep them out of
+  the blog feed/RSS.
+- **Storage (MVP)**: repo data — a typed array/data module
+  (`src/data/skills.ts`) for metadata, plus a per-skill markdown file for the
+  SKILL.md body (the body is too long to live inline in the array). Packaged
+  `.skill` files in `public/`. Exact file/folder layout pinned in `/ce:plan`.
+- **Entry fields** (per skill): `title`, `slug`, `description`, `tags` (string
+  array), `author` (slug ref into `src/data/authors.ts`), `repoUrl`,
+  `installCommand` (string — the `/plugin marketplace add …` form),
+  `skillFile` (path/URL to downloadable `.skill`), `skillBody` (SKILL.md, rendered
+  inline), `publishedAt`. Required: title, slug, description, repoUrl,
+  installCommand, skillBody. Optional: tags, skillFile, author.
+- **Install model**: Claude Code **plugin marketplace** — CC4M publishes its
+  skills as a marketplace; the copy command is `/plugin marketplace add …`
+  followed by the install step. Exact strings finalized in plan.
+- **Get-affordances**: all four (GitHub link, copy install command, `.skill`
+  download, inline SKILL.md) — confirmed required by the user.
+- **Index UX**: card grid — name, description, tags. No filter UI in v1; add a
+  tag filter later if entries pass ~15–20.
+- **SEO**: each detail page emits an OG image and `SoftwareApplication`-style
+  (or `CreativeWork`) JSON-LD with `author` = byline. Add an `OgPageKey`
+  (`'skills'`) in `src/lib/og/url.ts`; add routes to `customPages`/sitemap in
+  `astro.config.mjs`; append to `public/llms.txt` / `llms-full.txt`.
+- **Discoverability**: not auto-promoted at launch. Feature via hello bar / blog
+  cross-links once there are 3+ skills.
+
+## Resolved questions
+
+1. **CC4M marketplace** — *does not exist yet.* Creating a CC4M Claude Code
+   plugin marketplace is a **prerequisite** of this work. The `/plugin
+   marketplace add …` install command isn't "real" until that marketplace repo
+   exists. Plan must account for standing it up (or sequence the gallery behind
+   it). Until then, detail pages can still ship GitHub link + `.skill` download +
+   inline SKILL.md; the copy-install-command becomes live once the marketplace
+   lands.
+2. **Skill source of truth (MVP)** — *repo files.* The inline SKILL.md body
+   lives as a markdown file in the cc4m repo; the downloadable `.skill` is a
+   packaged file committed to the repo / served from `public/` (or R2). Fully
+   version-controlled, no GitHub fetch at build/request time. Packaging step
+   (how the `.skill` is produced) pinned in plan.
+3. **Launch set** — *1–3 skills for v1.* Small, curated launch (exact picks
+   chosen during/after planning). Comfortably within the static-file threshold,
+   confirms Approach B is right.
+4. **Marketplace sequencing** — *launch without the marketplace.* v1 ships the
+   gallery with three of the four affordances (GitHub link, `.skill` download,
+   inline SKILL.md). The copy-install-command is a **later increment**, wired in
+   once the CC4M marketplace exists. The gallery is not blocked on marketplace
+   work.
+
+## Open questions
+
+1. **OG image** — per-skill hero art, or a templated OG (name + tags on brand
+   background) via the existing Satori engine? Decide in plan.
+2. **`.skill` packaging step** — manual commit of the packaged file, or a build
+   script that produces it from the SKILL.md source? Decide in plan.
+
+## Next steps
+
+→ Resolve open questions, then `/compound-engineering:ce-plan` for implementation
+details (file layout for `src/data/skills.ts` + SKILL.md bodies, route files,
+detail-page get-affordances, OG `OgPageKey`, sitemap/llms.txt wiring, and a
+stubbed migration note toward the deferred Emdash D1 `skills` collection).

--- a/docs/plans/2026-06-09-001-feat-skills-gallery-plan.md
+++ b/docs/plans/2026-06-09-001-feat-skills-gallery-plan.md
@@ -1,0 +1,332 @@
+---
+title: Skills Gallery (/skills) — share CC4M Claude agent skills
+type: feat
+status: active
+date: 2026-06-09
+origin: docs/brainstorms/2026-06-09-skills-gallery-brainstorm.md
+---
+
+# ✨ Skills Gallery (`/skills`)
+
+## Overview
+
+A public `/skills` section on cc4.marketing where CC4 Marketing shares its own
+curated Claude agent skills (SKILL.md bundles), in the spirit of
+[kits.vibery.app](https://kits.vibery.app/) and the
+[Anduril naming skill](https://github.com/blacklogos/anduril-naming-skill).
+Positioning is **general CC4M skills** (not marketing-only).
+
+- **Index** `/skills/` — responsive card grid (name, description, tags), cloned
+  from `src/pages/blog/index.astro`.
+- **Detail** `/skills/<slug>/` — a shareable page per skill with three
+  get-affordances at launch: **(1)** link to the GitHub repo, **(2)** download
+  the packaged `.skill` file, **(3)** read the SKILL.md inline. Plus an explicit
+  **"How to install"** block (the marketplace copy-command affordance is deferred
+  — see below).
+
+**MVP storage:** repo-file-backed. Skill bodies live as markdown in an Astro
+**Content Collection** (`src/content/skills/*.md`), rendered with
+`getCollection` + `render` + `<Content/>` like the course modules — **but the
+route is forced SSR (`prerender = false`)**, because prerendering is "poison" on
+this site (Emdash middleware hijacks the prerender path → `/_emdash/admin/setup`
+redirect). Migration to Emdash D1 is deferred (see brainstorm: Approach A).
+
+**Deferred (not in this plan):** the copy `/plugin marketplace add …` install
+command and the `/publish-skill` authoring tool — both wait on a CC4M plugin
+marketplace that does not exist yet (see brainstorm: Resolved Q1, Q4).
+
+## Problem Statement / Motivation
+
+CC4M has shippable Claude skills but no public surface to share them. A gallery
+gives each skill a canonical, shareable URL (good for social + SEO), lets
+visitors actually get the skill, and establishes a content type distinct from the
+blog and the (separate, image-prompts) `/prompts` effort. Curated + authors-only
+keeps the editorial bar high with zero auth/moderation surface.
+
+> **Not** the image-prompts `/prompts` gallery
+> (`docs/brainstorms/2026-05-09-prompts-gallery-brainstorm.md`,
+> `docs/plans/2026-05-09-001-feat-prompts-gallery-plan.md`) — that one is
+> Emdash-D1-backed image prompts. This `/skills` feature is a separate,
+> content-collection-backed feature. The decision to **not** use D1 for skills
+> v1 is intentional (brainstorm: Approach B).
+
+## Proposed Solution
+
+Clone the blog's visual/structural patterns; swap the data layer to a static
+Content Collection; add an R2-backed download route and OG support.
+
+1. **`skills` Content Collection** in `src/content.config.ts` (Zod schema), files
+   under `src/content/skills/*.md`. Frontmatter holds metadata; markdown body is
+   the SKILL.md content rendered inline.
+2. **Index `/skills/index.astro`** (`prerender = false`) — `getCollection('skills')`,
+   filter out drafts, render the card grid + `CollectionPage`/`BreadcrumbList`
+   JSON-LD + empty state.
+3. **Detail `/skills/[slug].astro`** (`prerender = false`) — `getStaticPaths`-free
+   SSR lookup by slug (mirror `blog/[slug].astro` 404 redirect), `render()` the
+   body, three affordances + "How to install" block, single JSON-LD type +
+   `BreadcrumbList`.
+4. **Download route `/skills/[slug]/download.skill.ts`** (`prerender = false`) —
+   validate slug against the collection, `env.MEDIA.get(r2Key)` (mirror
+   `src/pages/og/blog/[slugHash].png.ts:39-43`), stream with
+   `Content-Disposition: attachment`, 404 (not 500) on miss, `noindex`.
+5. **OG**: add `'skills'` to `OgPageKey` (`src/lib/og/url.ts`) + a `skills` entry
+   in `STATIC_PAGES` (`src/lib/og/build.ts`); re-run `npm run prebuild` →
+   `public/og/pages/skills.png`. Per-skill OG deferred (open question).
+6. **SEO wiring**: `skillPages` array + `customPages` + a `serialize()` branch in
+   `astro.config.mjs`; entries in `public/llms.txt` + `public/llms-full.txt`; one
+   durable nav/footer entry point.
+
+## Technical Considerations
+
+- **SSR everywhere (no prerender).** Documented: prerendered pages get hijacked
+  by Emdash setup-check middleware. Both routes + the download + any OG endpoint
+  use `export const prerender = false`. (Learning:
+  `docs/solutions/integration-issues/emdash-astro6-cloudflare-workers-setup.md`.)
+- **Content Collection under SSR is unproven on this site** — it must be spiked
+  before building (Phase 1). Verify `render()` returns rendered HTML on a real
+  Cloudflare preview (not just `astro dev`) and that the static `skills`
+  collection doesn't collide with Emdash's live collection in `src/live.config.ts`.
+- **Download via Astro SSR route, not a Pages Function.** (SpecFlow corrected the
+  brainstorm: a `functions/` dir *does* exist — `functions/api/subscribe.js` —
+  but this is a **Workers** project where that convention is ignored. The real
+  reason for an SSR route is to reuse the R2-read pattern already proven in
+  `src/pages/og/blog/[slugHash].png.ts`.) R2 binding is `MEDIA` (`wrangler.jsonc`).
+- **Slug-validate before building the R2 key** — only fetch keys for slugs that
+  exist in the collection (no `../../secret.skill` traversal / arbitrary fetch).
+- **Copy buttons are free** — `CodeBlockCopy.astro` (rendered once in
+  `BaseLayout.astro:209`) auto-injects a copy button on every `<pre>`. The inline
+  SKILL.md's fenced code blocks get them with zero wiring. (Caveat: it has no
+  `aria-live` and a weak failure fallback — extend only if we surface a dedicated
+  "copy install command" later.)
+- **JSON-LD: pick ONE type, don't hedge.** Index = `CollectionPage` +
+  `BreadcrumbList`. Detail = **`SoftwareApplication`** (`applicationCategory:
+  "DeveloperApplication"`, `operatingSystem`, `offers` free) + `BreadcrumbList`.
+  Partial schema fails Google's Rich Results Test, so commit fully.
+- **Design tokens / card signature**: reuse `--rust`, `--mustard`, `--border-color`,
+  `--shadow-sm`, `--font-display`; hover = `translate(-4px,-4px)` +
+  `box-shadow: 8px 8px 0 var(--mustard)` + rust border. Honor
+  `prefers-reduced-motion`.
+- **Title length** ≤ 60 chars including the `| Claude Code for Marketers` suffix.
+- **Trailing slashes** on all internal links; unknown slug → `/404` redirect.
+
+## System-Wide Impact
+
+- **Interaction graph**: A request to `/skills/<slug>/` hits Astro SSR → Emdash
+  middleware (must pass through, not intercept) → `getCollection('skills')` +
+  `render()`. The download route hits the `MEDIA` R2 binding. OG resolution flows
+  through `resolveOgImage()` → `/og/pages/skills.png` (build-time asset).
+- **Error propagation**: unknown slug → `Astro.redirect('/404')` (mirror
+  `blog/[slug].astro:16`). Missing R2 object → **404, never 500** + on-page
+  "download unavailable, use GitHub" fallback. `env.MEDIA` undefined in local dev
+  → graceful degrade (mirror the OG route's tolerance).
+- **State lifecycle risks**: source-of-truth divergence — inline SKILL.md
+  (`src/content/skills/*.md`) vs. the downloaded `.skill` (R2). Define a sync rule
+  (the repo markdown is canonical; the `.skill` is packaged from the same commit)
+  and document the packaging/upload step so the two can't drift.
+- **API surface parity**: `customPages` + `serialize` in `astro.config.mjs`,
+  `OgPageKey` union + `STATIC_PAGES`, `llms.txt` + `llms-full.txt` — every one is
+  a **hand-maintained** list. Adding a skill touches all of them; until a
+  `/publish-skill` skill exists (deferred), this is a documented manual checklist.
+- **Integration test scenarios**:
+  1. Cloudflare preview deploy: `/skills/<slug>/` returns 200 with rendered
+     `<Content/>` HTML (the spike's core assertion).
+  2. `/skills/` with 0 published skills → `noindex` + friendly empty state, layout
+     intact.
+  3. Download of a slug whose `.skill` is absent from R2 → 404 + page fallback,
+     no 500.
+  4. Emdash blog still renders and `_emdash` live collection unaffected
+     (regression).
+  5. `sitemap.xml` post-deploy contains every `/skills/*` URL.
+
+## Implementation Phases
+
+### Phase 1 — Spike (GATE: must pass before Phase 2) — ✅ PASSED 2026-06-09
+
+- [x] Add a throwaway `skills` collection + one `src/content/skills/test.md`.
+- [x] Stub `src/pages/skills/[slug].astro` with `prerender = false`,
+      `getCollection` + `render` + `<Content/>`.
+- [x] Confirm `/skills/test/` returns 200 with rendered HTML in the **workerd
+      Cloudflare runtime** (`wrangler dev --local`, all D1/R2/Emdash bindings
+      active — a faithful production proxy, stronger than `astro dev`).
+- [x] Confirm Emdash `src/live.config.ts` middleware doesn't intercept/error on
+      `/skills/*` (no `/_emdash/admin/setup` redirect); static `skills` collection
+      coexists with the live `_emdash` collection; `astro sync` clean; blog index
+      regression 200.
+- [x] Unknown slug → `/404` (302) verified.
+- [x] Copy button auto-injects on `<pre>` (`code-copy-btn` present via BaseLayout).
+
+**Result:** Content-Collection-under-SSR is proven on this site. **No fallback
+needed** — Phase 2 builds directly on this pattern. (Raw `?raw` import fallback
+remains the documented contingency if a future Emdash upgrade regresses this.)
+
+### Phase 2 — Index + Detail (static content) — ✅ DONE
+
+- [x] `src/content.config.ts`: add `skills` collection + Zod schema —
+      `name`, `description`, `tags` (optional), `repo` (url, optional),
+      `skillFile` (optional), `author` (optional), `draft` (default false),
+      `publishedAt`, `updatedAt` (optional). (Slug derives from filename.)
+- [x] `src/content/skills/<slug>.md` × 2 launch skills (naming, brand-voice;
+      realistic placeholders, body = SKILL.md).
+- [x] `src/pages/skills/index.astro` (`prerender = false`): grid, drafts filtered,
+      empty state (`noindex` when 0), `CollectionPage` + `BreadcrumbList` JSON-LD,
+      `BaseLayout` with `ogPageKey="skills"`, `showCourseSchema={false}`,
+      `showBreadcrumb={false}`. Grid uses `auto-fill` + `minmax(280px,320px)` +
+      `justify-content:start` so 1–2 cards left-align. `prefers-reduced-motion`
+      honored.
+- [x] `src/pages/skills/[slug].astro` (`prerender = false`): SSR lookup, 404 on
+      miss, `render()` body, three affordances, **"How to install" block**,
+      conditional GitHub link (hidden if `repo` absent),
+      `SoftwareApplication` + `BreadcrumbList` JSON-LD.
+
+### Phase 3 — Download route + R2 — ✅ DONE (route); ⏳ upload deferred
+
+- [x] `slug → R2 key` contract documented: object key is `skills/<skillFile>`
+      (e.g. `skills/naming.skill`). MVP upload = manual `wrangler r2 object put`
+      (see Open Questions / packaging step).
+- [x] `src/pages/skills/[slug]/download.skill.ts` (`prerender = false`):
+      slug-validate against collection (traversal-safe) → `env.MEDIA.get(key)` →
+      stream with `Content-Type: application/octet-stream` +
+      `Content-Disposition: attachment; filename="<slug>.skill"` +
+      immutable `Cache-Control` + `X-Robots-Tag: noindex`; **404 (not 500)** on
+      miss (verified locally); dev-safe when `env.MEDIA` undefined.
+- [x] Detail page shows a "download unavailable — use GitHub" fallback when no
+      `skillFile` is set.
+- [ ] **Upload the actual `.skill` files to R2** (`skills/naming.skill`,
+      `skills/brand-voice.skill`) — pending real packaged artifacts.
+
+### Phase 4 — OG, SEO, discoverability — ✅ DONE
+
+- [x] `src/lib/og/url.ts`: added `'skills'` to `OgPageKey`.
+- [x] `src/lib/og/build.ts`: added `skills` to `STATIC_PAGES`;
+      `public/og/pages/skills.png` emitted (42 KB, verified).
+- [x] `astro.config.mjs`: `skillPages` array (index + both skills, trailing
+      slashes) → `customPages`; `serialize()` branch for `/skills/`; sitemap
+      filter excludes `/download.skill`. Sitemap output verified.
+- [x] `public/llms.txt`: `Skills:` line under `## Site Structure` + `## Skills`
+      section. `public/llms-full.txt`: `## Skills` section with per-skill
+      Path / Description / Install / What-it-does blocks.
+- [x] Durable entry point: `Skills` added to header nav (`src/config/siteData.ts`).
+- [ ] Re-run `/seo-audit` after deploy; verify `curl robots.txt` has no
+      Cloudflare-managed AI-bot block re-enabled. (Post-deploy.)
+
+## Acceptance Criteria
+
+**Spike gate** — ✅ PASSED 2026-06-09 (workerd via `wrangler dev --local`)
+- [x] `/skills/test/` returns 200 with rendered `<Content/>` HTML in the
+      Cloudflare workerd runtime.
+- [x] Emdash `src/live.config.ts` doesn't intercept `/skills/*`; static + live
+      collections coexist.
+- [x] Fallback path documented (raw `?raw` import) — not needed; spike passed.
+
+**Functional**
+- [ ] `/skills/` renders all non-draft skills as cards (name, description, tags).
+- [ ] 0-skill state → `noindex` + friendly message, layout intact; 1–2 card grids
+      left-align.
+- [ ] `/skills/<slug>/` renders name, description, tags, inline SKILL.md, and
+      every available affordance.
+- [ ] Unknown slug → `/404` redirect, verified under SSR on Cloudflare.
+- [ ] Skill with no `repo` hides the GitHub affordance cleanly.
+- [ ] Detail page includes an explicit, copy-pasteable **"How to install this
+      skill"** section (marketplace command deferred).
+- [ ] `draft: true` skills are excluded from index, detail, sitemap, and llms.txt.
+
+**Download route**
+- [ ] Serves `.skill` from R2 with `Content-Type` + `Content-Disposition:
+      attachment; filename="<slug>.skill"` + `Cache-Control`.
+- [ ] Missing R2 object → 404 (not 500) **and** page shows GitHub fallback.
+- [ ] `env.MEDIA` undefined (local dev) degrades gracefully.
+- [ ] Slug validated against the collection before building the R2 key (no
+      arbitrary-key fetch / traversal).
+- [ ] Download route is `noindex` and absent from the sitemap.
+- [ ] Inline SKILL.md and the downloaded `.skill` are the same version (sync rule
+      defined + documented).
+
+**SEO / discoverability**
+- [ ] Every `/skills/` and `/skills/<slug>/` URL appears in `sitemap.xml`
+      post-deploy, with a `/skills/` `serialize()` branch.
+- [ ] `'skills'` added to `OgPageKey` and `STATIC_PAGES`;
+      `public/og/pages/skills.png` emitted by the build.
+- [ ] `showCourseSchema={false}` + `showBreadcrumb={false}` on both routes; index
+      = `CollectionPage` + `BreadcrumbList`, detail = `SoftwareApplication` +
+      `BreadcrumbList`, both pass Google Rich Results Test.
+- [ ] `llms.txt` + `llms-full.txt` contain every skill.
+- [ ] At least one durable nav/footer entry point to `/skills/`.
+- [ ] Trailing-slash canonical enforced.
+
+**Quality gates**
+- [ ] Lighthouse a11y ≥ 95 on index + each detail page.
+- [ ] Cards: one accessible link per card, non-interactive tags, correct image
+      `alt`, keyboard-operable, `prefers-reduced-motion` honored.
+- [ ] Download control keyboard-operable with a discernible name.
+- [ ] Title ≤ 60 chars incl. suffix.
+- [ ] No regression to blog OG, blog index, or the Emdash `_emdash` live
+      collection.
+
+## Success Metrics
+
+Gallery live with 1–3 CC4M skills, each with a shareable detail URL, working
+GitHub link + `.skill` download + inline SKILL.md + install instructions, indexed
+in `sitemap.xml` and `llms.txt`, reachable from a durable nav entry. (Brainstorm
+success criteria.)
+
+## Dependencies & Risks
+
+- **Risk (high): Content Collection under SSR is unproven here** → mitigated by
+  the Phase 1 spike gate with a documented raw-import fallback.
+- **Risk (med): prerender hijack** by Emdash middleware → mitigated by
+  `prerender = false` on every route, asserted on a real preview deploy.
+- **Risk (med): hand-maintained sitemap/llms.txt/customPages drift** → documented
+  manual checklist for MVP; a `/publish-skill` skill (deferred) automates later.
+- **Risk (low): `.skill` ↔ SKILL.md version drift** → repo markdown canonical,
+  `.skill` packaged from same commit; documented.
+- **Dependency: marketplace** does not exist → copy-install affordance + the
+  `/publish-skill` skill are explicitly out of scope (brainstorm: Resolved Q1/Q4).
+
+## Open Questions (carried from brainstorm + research)
+
+1. **Per-skill OG image** — reuse the single `skills.png` page key for all skills
+   (cheap, ship now), or add a build-time per-skill OG (extend `build.ts` to
+   iterate `src/content/skills`, emit `public/og/skills/<slug>.png`, add a
+   `resolveOgImage` branch)? *Lean: single key for MVP.*
+2. **`.skill` packaging step** — manual `wrangler r2 object put` for MVP vs. a
+   build script. *Lean: manual for 1–3 skills.*
+3. **Tag interactivity** — decorative now (non-interactive chips); add
+   `/skills/?tag=` filter only past ~15 entries.
+
+## Sources & References
+
+### Origin
+- **Brainstorm:** [docs/brainstorms/2026-06-09-skills-gallery-brainstorm.md](../brainstorms/2026-06-09-skills-gallery-brainstorm.md)
+  — carried forward: Approach B (static repo-file MVP, defer D1); three
+  get-affordances at launch (copy-install deferred); general CC4M positioning;
+  1–3 launch skills; launch without the marketplace.
+
+### Internal references
+- `src/pages/blog/index.astro` — card grid + `CollectionPage` JSON-LD (clone).
+- `src/pages/blog/[slug].astro:16` — SSR 404 redirect pattern; prose CSS.
+- `src/pages/modules/[...slug].astro` — `getCollection` + `render` + `<Content/>`.
+- `src/content.config.ts` — collection + Zod schema location.
+- `src/live.config.ts` — Emdash live-collection collision check (spike).
+- `src/pages/og/blog/[slugHash].png.ts:39-43` — R2-read pattern for the download.
+- `src/lib/og/url.ts:17` — `OgPageKey` union; `src/lib/og/build.ts:126` —
+  `STATIC_PAGES`.
+- `astro.config.mjs:50,69,77` — `blogPages`/`customPages`/`serialize`.
+- `src/layouts/BaseLayout.astro:209` — `CodeBlockCopy` global include.
+- `src/components/CodeBlockCopy.astro:49` — weak failure fallback, no `aria-live`.
+- `wrangler.jsonc` — `MEDIA` (R2), `DB` (D1) bindings.
+
+### Learnings (docs/solutions/)
+- `integration-issues/emdash-astro6-cloudflare-workers-setup.md` — **prerender is
+  poison**; SSR everywhere; trailing slashes; no `not_found_handling`.
+- `integration-issues/workers-og-bundle-size-measurement.md` — OG endpoints need
+  `prerender=false`; Satori rejects WOFF2; no `_`-prefixed route files.
+- `integration-issues/emdash-d1-blog-post-publishing-workflow.md` — SSR routes
+  invisible to sitemap → hand-add to `customPages`.
+- `seo-issues/comprehensive-seo-aeo-audit-fixes.md` — `showCourseSchema={false}` +
+  `showBreadcrumb={false}`; manually update `llms.txt`; verify robots.txt.
+- `integration-issues/cloudflare-workers-assets-with-api-routes.md` — Workers (not
+  Pages); R2 downloads via SSR route + `MEDIA` binding.
+
+### Related work
+- `docs/plans/2026-05-09-001-feat-prompts-gallery-plan.md` — the *separate*
+  `/prompts` image-gallery (D1-backed); pattern reference only, not this feature.

--- a/docs/plans/2026-06-09-001-feat-skills-gallery-plan.md
+++ b/docs/plans/2026-06-09-001-feat-skills-gallery-plan.md
@@ -282,6 +282,23 @@ success criteria.)
 - **Dependency: marketplace** does not exist → copy-install affordance + the
   `/publish-skill` skill are explicitly out of scope (brainstorm: Resolved Q1/Q4).
 
+## Post-MVP enhancement — skill "stack" cart + tabbed install (✅ DONE)
+
+Inspired by kits.vibery.app's buffet/cart UX:
+- **Cart**: `src/components/SkillCart.astro` — select multiple skills across the
+  gallery ("Add to stack" on each card + detail page), persistent bottom tray
+  with a count, and a checkout panel. State in localStorage (vanilla JS, matches
+  `CodeBlockCopy.astro` idiom); persists across navigation; syncs across tabs.
+- **Checkout output**: a single copy-all block of `git clone <repo>
+  ~/.claude/skills/<slug>` commands (+ `mkdir -p`) for every selected skill,
+  plus a download list of the `.skill` files. Marketplace command still deferred.
+- **Detail install**: replaced the plain list with a tabbed panel (git clone /
+  Download), each command in a dark terminal block with the site's copy button.
+- **Gotcha fixed**: the HTML `hidden` attribute is overridden by an explicit
+  `display:flex`, so the tray/modal need `[hidden]{display:none!important}`.
+  Also exempted the cart's command `<pre>` from the global `CodeBlockCopy`
+  auto-inject via `[data-no-copy-btn]` (it has its own copy-all button).
+
 ## Open Questions (carried from brainstorm + research)
 
 1. **Per-skill OG image** — reuse the single `skills.png` page key for all skills

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -16,6 +16,22 @@ The CC4.Marketing blog publishes practical guides on AI-powered marketing with C
 - [The Last Mile of Shipping Is the Hardest Part](https://cc4.marketing/blog/the-last-mile-of-shipping/) — On turning the manual, undocumented steps between build and ship into a system of slash commands that compound over time.
 - [castmd: Vibe Coding a Chrome Extension for LLMs](https://cc4.marketing/blog/castmd-vibe-coding-chrome-extension/) — How Tri Vo rebuilt md·convert into castmd — a Chrome extension that converts web pages to Markdown, JSON, or Claude XML — using vibe coding with Claude Code.
 
+## Skills
+Curated Claude agent skills (SKILL.md bundles) from the CC4 Marketing team. Each skill page renders the SKILL.md inline and offers the GitHub source, a downloadable `.skill` file, and install instructions.
+- Skills index: https://cc4.marketing/skills/
+
+### Skill: Naming Skill
+Path: https://cc4.marketing/skills/naming/
+Description: Turn an abstract naming brief into scored, narrative-backed name candidates — for brands, products, features, campaigns, and codenames.
+Install: Download the .skill file (or clone the repo), place it in ~/.claude/skills/, restart Claude Code.
+What it does: Builds a naming brief, generates name clusters, scores candidates on memorability and distinctiveness, and presents a narrated shortlist. Does not perform trademark screening.
+
+### Skill: Brand Voice Skill
+Path: https://cc4.marketing/skills/brand-voice/
+Description: Review and rewrite copy against a defined brand voice, tone, and language standard.
+Install: Download the .skill file (or clone the repo), place it in ~/.claude/skills/, restart Claude Code.
+What it does: Loads a brand voice guide, scores drafts against it, flags off-brand phrasing, and proposes on-brand rewrites with reasoning.
+
 ## Module 0: Getting Started (4 lessons, ~30 minutes)
 
 ### Lesson 0.0 — Introduction (10 min)

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,6 +9,7 @@ CC4.Marketing is an open-source course that teaches AI-powered marketing workflo
 - Homepage: https://cc4.marketing/
 - Blog: https://cc4.marketing/blog/
 - Blog Authors: https://cc4.marketing/blog/authors/
+- Skills: https://cc4.marketing/skills/
 - Course Modules: https://cc4.marketing/modules/{module}/{lesson-slug}/
 - Changelog: https://cc4.marketing/changelog/
 - Download/Subscribe: https://cc4.marketing/download/
@@ -24,6 +25,13 @@ The blog publishes practical guides, tutorials, and insights on AI-powered marke
 - [AI Works Best When It Looks at What You've Already Shipped](https://cc4.marketing/blog/ai-workflows-not-automation/)
 - [The Last Mile of Shipping Is the Hardest Part](https://cc4.marketing/blog/the-last-mile-of-shipping/)
 - [castmd: Vibe Coding a Chrome Extension for LLMs](https://cc4.marketing/blog/castmd-vibe-coding-chrome-extension/)
+
+## Skills
+Curated Claude agent skills (SKILL.md bundles) from the CC4 Marketing team. Each skill has a shareable page with the rendered SKILL.md, a link to its GitHub source, a downloadable `.skill` file, and install instructions.
+
+### Available Skills
+- [Naming Skill](https://cc4.marketing/skills/naming/) — Turn an abstract naming brief into scored, narrative-backed name candidates.
+- [Brand Voice Skill](https://cc4.marketing/skills/brand-voice/) — Review and rewrite copy against a defined brand voice, tone, and language standard.
 
 ## Course Modules
 - Module 0: Getting Started (4 lessons, 30 min) — Installation, setup, first task

--- a/src/components/CodeBlockCopy.astro
+++ b/src/components/CodeBlockCopy.astro
@@ -13,6 +13,11 @@
         return;
       }
 
+      // Skip blocks that manage their own copy affordance (e.g. the skill cart).
+      if (pre.closest('[data-no-copy-btn]')) {
+        return;
+      }
+
       // Create wrapper
       const wrapper = document.createElement('div');
       wrapper.className = 'code-block-wrapper';

--- a/src/components/SkillCart.astro
+++ b/src/components/SkillCart.astro
@@ -1,0 +1,470 @@
+---
+// Persistent "skill stack" cart: select skills across the gallery, then check
+// out with one combined install block. State lives in localStorage so it
+// survives navigation. Vanilla JS to match the site's zero-framework idiom
+// (see CodeBlockCopy.astro).
+//
+// Pages opt in by:
+//   1. rendering <SkillCart /> once (it injects the tray + checkout panel), and
+//   2. giving each "add" control a [data-skill-add] with data-slug / data-name /
+//      data-repo / data-skill-file attributes.
+---
+
+<div id="skill-cart" class="skill-cart" hidden aria-live="polite">
+  <div class="skill-cart-bar">
+    <button type="button" id="skill-cart-toggle" class="skill-cart-toggle" aria-expanded="false" aria-controls="skill-cart-panel">
+      <span class="skill-cart-icon" aria-hidden="true">🎒</span>
+      <span class="skill-cart-label">Your stack</span>
+      <span id="skill-cart-count" class="skill-cart-count">0</span>
+    </button>
+    <button type="button" id="skill-cart-checkout" class="skill-cart-checkout">Check out →</button>
+  </div>
+</div>
+
+<div id="skill-cart-panel" class="skill-cart-panel" hidden role="dialog" aria-modal="true" aria-labelledby="skill-cart-panel-title">
+  <div class="skill-cart-panel-inner">
+    <header class="skill-cart-panel-head">
+      <h2 id="skill-cart-panel-title">Install your stack</h2>
+      <button type="button" id="skill-cart-close" class="skill-cart-close" aria-label="Close">✕</button>
+    </header>
+
+    <p class="skill-cart-panel-sub">
+      Run these from your terminal to add every selected skill to Claude Code, then restart it.
+    </p>
+
+    <div class="skill-cart-commands" data-no-copy-btn>
+      <button type="button" id="skill-cart-copyall" class="skill-cart-copyall">Copy all commands</button>
+      <pre id="skill-cart-script"><code></code></pre>
+    </div>
+
+    <div id="skill-cart-downloads" class="skill-cart-downloads">
+      <h3>Or download the packaged skills</h3>
+      <ul id="skill-cart-download-list"></ul>
+    </div>
+
+    <footer class="skill-cart-panel-foot">
+      <button type="button" id="skill-cart-clear" class="skill-cart-clear">Clear stack</button>
+    </footer>
+  </div>
+</div>
+
+<script>
+  type CartItem = { slug: string; name: string; repo?: string; skillFile?: string };
+
+  const KEY = 'cc4m-skill-stack';
+
+  function read(): CartItem[] {
+    try {
+      const raw = localStorage.getItem(KEY);
+      const parsed = raw ? JSON.parse(raw) : [];
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+
+  function write(items: CartItem[]): void {
+    try {
+      localStorage.setItem(KEY, JSON.stringify(items));
+    } catch {
+      /* storage unavailable (private mode) — cart is in-memory for this view */
+    }
+  }
+
+  function cloneCommand(item: CartItem): string {
+    if (item.repo) {
+      return `git clone ${item.repo} ~/.claude/skills/${item.slug}`;
+    }
+    return `# ${item.name}: see https://cc4.marketing/skills/${item.slug}/ for install steps`;
+  }
+
+  function buildScript(items: CartItem[]): string {
+    if (items.length === 0) return '';
+    return [
+      '# CC4.Marketing skill stack — run these, then restart Claude Code',
+      'mkdir -p ~/.claude/skills',
+      ...items.map(cloneCommand),
+    ].join('\n');
+  }
+
+  function setupSkillCart(): void {
+    const cart = document.getElementById('skill-cart');
+    const panel = document.getElementById('skill-cart-panel');
+    if (!cart || !panel) return;
+
+    const countEl = document.getElementById('skill-cart-count')!;
+    const scriptEl = panel.querySelector<HTMLElement>('#skill-cart-script code')!;
+    const downloadsEl = document.getElementById('skill-cart-downloads')!;
+    const downloadList = document.getElementById('skill-cart-download-list')!;
+
+    // The checkout panel always starts closed (so back/forward navigation via
+    // pageshow never restores it mid-open).
+    panel.hidden = true;
+
+    function refreshAddButtons(items: CartItem[]): void {
+      const slugs = new Set(items.map((i) => i.slug));
+      document.querySelectorAll<HTMLElement>('[data-skill-add]').forEach((btn) => {
+        const inStack = slugs.has(btn.dataset.slug || '');
+        btn.classList.toggle('in-stack', inStack);
+        btn.setAttribute('aria-pressed', String(inStack));
+        const label = btn.querySelector('[data-add-label]');
+        if (label) label.textContent = inStack ? 'In stack ✓' : 'Add to stack';
+      });
+    }
+
+    function render(): void {
+      const items = read();
+      countEl.textContent = String(items.length);
+      cart.hidden = items.length === 0;
+
+      scriptEl.textContent = buildScript(items);
+
+      const withFiles = items.filter((i) => i.skillFile);
+      downloadsEl.hidden = withFiles.length === 0;
+      downloadList.innerHTML = '';
+      for (const item of withFiles) {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = `/skills/${item.slug}/download.skill`;
+        a.setAttribute('download', `${item.slug}.skill`);
+        a.textContent = `${item.name} (.skill)`;
+        li.appendChild(a);
+        downloadList.appendChild(li);
+      }
+
+      refreshAddButtons(items);
+    }
+
+    function toggleItem(data: CartItem): void {
+      const items = read();
+      const idx = items.findIndex((i) => i.slug === data.slug);
+      if (idx >= 0) items.splice(idx, 1);
+      else items.push(data);
+      write(items);
+      render();
+    }
+
+    function openPanel(): void {
+      if (read().length === 0) return; // nothing to check out
+      panel.hidden = false;
+      document.getElementById('skill-cart-toggle')?.setAttribute('aria-expanded', 'true');
+      (document.getElementById('skill-cart-close') as HTMLElement | null)?.focus();
+    }
+
+    function closePanel(): void {
+      panel.hidden = true;
+      document.getElementById('skill-cart-toggle')?.setAttribute('aria-expanded', 'false');
+    }
+
+    // Wire add buttons (delegated so it works for any [data-skill-add] on the page).
+    document.querySelectorAll<HTMLElement>('[data-skill-add]').forEach((btn) => {
+      if (btn.dataset.cartBound) return;
+      btn.dataset.cartBound = '1';
+      btn.addEventListener('click', (e) => {
+        e.preventDefault();
+        toggleItem({
+          slug: btn.dataset.slug || '',
+          name: btn.dataset.name || btn.dataset.slug || '',
+          repo: btn.dataset.repo || undefined,
+          skillFile: btn.dataset.skillFile || undefined,
+        });
+      });
+    });
+
+    document.getElementById('skill-cart-checkout')?.addEventListener('click', openPanel);
+    document.getElementById('skill-cart-toggle')?.addEventListener('click', openPanel);
+    document.getElementById('skill-cart-close')?.addEventListener('click', closePanel);
+    panel.addEventListener('click', (e) => {
+      if (e.target === panel) closePanel();
+    });
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && !panel.hidden) closePanel();
+    });
+
+    document.getElementById('skill-cart-clear')?.addEventListener('click', () => {
+      write([]);
+      render();
+      closePanel();
+    });
+
+    const copyAll = document.getElementById('skill-cart-copyall');
+    copyAll?.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(buildScript(read()));
+        const prev = copyAll.textContent;
+        copyAll.textContent = 'Copied!';
+        copyAll.classList.add('copied');
+        setTimeout(() => {
+          copyAll.textContent = prev;
+          copyAll.classList.remove('copied');
+        }, 2000);
+      } catch (err) {
+        console.error('Copy failed', err);
+      }
+    });
+
+    // Reflect changes made in other tabs/pages.
+    window.addEventListener('storage', (e) => {
+      if (e.key === KEY) render();
+    });
+
+    render();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setupSkillCart);
+  } else {
+    setupSkillCart();
+  }
+  window.addEventListener('pageshow', setupSkillCart);
+</script>
+
+<style>
+  /* The `hidden` attribute must win over the display rules below, or the tray
+     and modal stay visible when emptied/closed. */
+  .skill-cart[hidden],
+  .skill-cart-panel[hidden] {
+    display: none !important;
+  }
+
+  /* Persistent bottom tray */
+  .skill-cart {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 50;
+    display: flex;
+    justify-content: center;
+    padding: 0 16px 16px;
+    pointer-events: none;
+  }
+
+  .skill-cart-bar {
+    pointer-events: auto;
+    display: flex;
+    align-items: stretch;
+    gap: 0;
+    background: var(--bg-secondary);
+    border: 2px solid var(--charcoal);
+    box-shadow: 6px 6px 0 var(--mustard);
+    max-width: 480px;
+    width: 100%;
+  }
+
+  .skill-cart-toggle {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: transparent;
+    border: none;
+    border-right: 2px solid var(--border-color);
+    padding: 14px 18px;
+    font-size: 0.95em;
+    font-weight: 600;
+    color: var(--text-primary);
+    cursor: pointer;
+  }
+
+  .skill-cart-icon {
+    font-size: 1.2em;
+  }
+
+  .skill-cart-count {
+    margin-left: auto;
+    min-width: 24px;
+    height: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--rust);
+    color: var(--cream);
+    font-size: 0.8em;
+    font-weight: 700;
+    border-radius: 999px;
+    padding: 0 7px;
+  }
+
+  .skill-cart-checkout {
+    background: var(--rust);
+    color: var(--cream);
+    border: none;
+    padding: 14px 22px;
+    font-size: 0.95em;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background 0.2s ease;
+  }
+
+  .skill-cart-checkout:hover {
+    background: var(--charcoal);
+  }
+
+  /* Checkout panel (modal) */
+  .skill-cart-panel {
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+  }
+
+  .skill-cart-panel-inner {
+    background: var(--bg-primary);
+    border: 2px solid var(--charcoal);
+    box-shadow: 8px 8px 0 var(--mustard);
+    max-width: 640px;
+    width: 100%;
+    max-height: 85vh;
+    overflow-y: auto;
+    padding: 28px;
+  }
+
+  .skill-cart-panel-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+  }
+
+  .skill-cart-panel-head h2 {
+    font-family: var(--font-display);
+    font-size: 1.5em;
+    margin: 0;
+    color: var(--text-primary);
+  }
+
+  .skill-cart-close {
+    background: transparent;
+    border: 2px solid var(--border-color);
+    width: 36px;
+    height: 36px;
+    font-size: 1em;
+    cursor: pointer;
+    color: var(--text-primary);
+  }
+
+  .skill-cart-close:hover {
+    border-color: var(--rust);
+    color: var(--rust);
+  }
+
+  .skill-cart-panel-sub {
+    color: var(--text-secondary);
+    font-size: 0.95em;
+    margin: 0 0 20px;
+  }
+
+  .skill-cart-commands {
+    position: relative;
+    margin-bottom: 24px;
+    border: 2px solid #2a2a2a;
+    background: #1c1c1c;
+  }
+
+  .skill-cart-copyall {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    background: #2d2d2d;
+    border: 1px solid #4a4a4a;
+    color: #eaeaea;
+    font-size: 0.8em;
+    font-weight: 600;
+    padding: 5px 12px;
+    cursor: pointer;
+    z-index: 1;
+  }
+
+  .skill-cart-copyall:hover {
+    border-color: var(--rust);
+    color: var(--rust);
+  }
+
+  .skill-cart-copyall.copied {
+    border-color: #7fb069;
+    color: #7fb069;
+  }
+
+  .skill-cart-commands pre {
+    background: transparent;
+    color: #eaeaea;
+    border: none;
+    padding: 16px;
+    padding-top: 40px;
+    margin: 0;
+    font-size: 0.85em;
+    line-height: 1.6;
+    /* Wrap long clone commands rather than horizontal-scroll, so the full
+       command is visible and copy-pasteable at a glance. */
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+
+  .skill-cart-commands pre code {
+    color: inherit;
+    background: transparent;
+    border: none;
+    padding: 0;
+  }
+
+  .skill-cart-downloads h3 {
+    font-family: var(--font-display);
+    font-size: 1em;
+    color: var(--text-primary);
+    margin: 0 0 12px;
+  }
+
+  .skill-cart-download-list,
+  #skill-cart-download-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 20px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  #skill-cart-download-list a {
+    display: inline-block;
+    font-size: 0.85em;
+    font-weight: 600;
+    color: var(--rust);
+    border: 2px solid var(--rust);
+    padding: 6px 14px;
+    text-decoration: none;
+  }
+
+  #skill-cart-download-list a:hover {
+    background: var(--rust);
+    color: var(--cream);
+  }
+
+  .skill-cart-panel-foot {
+    border-top: 2px solid var(--border-color);
+    padding-top: 16px;
+  }
+
+  .skill-cart-clear {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 0.85em;
+    cursor: pointer;
+    text-decoration: underline;
+  }
+
+  .skill-cart-clear:hover {
+    color: var(--rust);
+  }
+
+  @media (max-width: 640px) {
+    .skill-cart-panel-inner {
+      padding: 20px;
+    }
+  }
+</style>

--- a/src/config/siteData.ts
+++ b/src/config/siteData.ts
@@ -6,6 +6,7 @@ export const siteData = {
     { label: 'Home', href: '/' },
     { label: 'Modules', href: '/#modules' },
     { label: 'Blog', href: '/blog/' },
+    { label: 'Skills', href: '/skills/' },
     { label: 'Changelog', href: '/changelog/' },
     { label: 'GitHub', href: 'https://github.com/cc4-marketing/cc4.marketing', external: true },
   ],

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -15,6 +15,30 @@ const modulesCollection = defineCollection({
   }),
 });
 
+// Skills gallery (/skills). Each markdown file is one CC4M Claude agent skill;
+// the frontmatter is metadata, the body is the SKILL.md rendered inline.
+// Rendered under SSR (prerender = false) — verified in Phase 1 spike.
+const skillsCollection = defineCollection({
+  loader: glob({ pattern: '**/*.md', base: './src/content/skills' }),
+  schema: z.object({
+    name: z.string(),
+    description: z.string(),
+    tags: z.array(z.string()).optional(),
+    // GitHub repo for the skill's source; affordance hidden when absent.
+    repo: z.string().url().optional(),
+    // R2 object key for the packaged download; the download route 404s cleanly
+    // (with an on-page GitHub fallback) when the object is missing.
+    skillFile: z.string().optional(),
+    // Byline slug; reserved for future author cross-linking.
+    author: z.string().optional(),
+    // File present + draft=false => live. draft entries are excluded everywhere.
+    draft: z.boolean().default(false),
+    publishedAt: z.coerce.date(),
+    updatedAt: z.coerce.date().optional(),
+  }),
+});
+
 export const collections = {
   modules: modulesCollection,
+  skills: skillsCollection,
 };

--- a/src/content/skills/brand-voice.md
+++ b/src/content/skills/brand-voice.md
@@ -1,0 +1,37 @@
+---
+name: Brand Voice Skill
+description: Keep every piece of copy on-brand — review and rewrite text against a defined voice, tone, and language standard.
+tags:
+  - brand
+  - writing
+  - editing
+repo: https://github.com/cc4marketing/brand-voice-skill
+skillFile: brand-voice.skill
+author: tri-vo
+draft: false
+publishedAt: 2026-06-09
+---
+
+# Brand Voice Skill
+
+Load your brand's voice once, then have Claude review or rewrite any copy to match
+it. The skill scores drafts against your voice rules, flags off-brand phrasing,
+and proposes on-brand rewrites with the reasoning shown.
+
+## What it's good for
+
+- Reviewing copy before it ships
+- Rewriting drafts to match a defined voice
+- Onboarding new writers to a brand's standards
+
+## How it works
+
+1. **Define** — point the skill at your voice/tone/language guide.
+2. **Review** — it scores a draft and flags each off-brand span.
+3. **Rewrite** — on-brand alternatives with a one-line rationale each.
+
+## Example
+
+```text
+> Use the brand voice skill to review this landing page headline.
+```

--- a/src/content/skills/brand-voice.md
+++ b/src/content/skills/brand-voice.md
@@ -5,7 +5,7 @@ tags:
   - brand
   - writing
   - editing
-repo: https://github.com/cc4marketing/brand-voice-skill
+repo: https://github.com/cc4-marketing/brand-voice-skill
 skillFile: brand-voice.skill
 author: tri-vo
 draft: false

--- a/src/content/skills/naming.md
+++ b/src/content/skills/naming.md
@@ -1,0 +1,45 @@
+---
+name: Naming Skill
+description: Turn an abstract naming brief into scored, narrative-backed name candidates — for brands, products, features, campaigns, and codenames.
+tags:
+  - naming
+  - branding
+  - strategy
+repo: https://github.com/cc4marketing/naming-skill
+skillFile: naming.skill
+author: tri-vo
+draft: false
+publishedAt: 2026-06-09
+---
+
+# Naming Skill
+
+A structured naming workflow for Claude. It converts a loose naming need into an
+organized brief, generates name clusters from mythological and cultural sources,
+scores each candidate on memorability and distinctiveness, and presents a
+shortlist with a short narrative (Origin → Transformation → Destiny) for each.
+
+> This skill does **not** perform trademark or legal screening. Always run a
+> separate trademark check before committing to a name.
+
+## What it's good for
+
+- Product and feature names
+- Brand and campaign names
+- Internal codenames
+
+## How it works
+
+1. **Brief** — clarifying questions turn your need into a one-page brief.
+2. **Generate** — name clusters from distinct inspiration sources.
+3. **Score** — each candidate rated on memorability + distinctiveness.
+4. **Shortlist** — top candidates with an Origin → Transformation → Destiny story.
+
+## Example
+
+```text
+> Use the naming skill. We need a name for a privacy-first analytics product.
+```
+
+The skill replies with a brief, ~20 candidates across 4 clusters, scores, and a
+narrated shortlist of 5.

--- a/src/content/skills/naming.md
+++ b/src/content/skills/naming.md
@@ -5,7 +5,7 @@ tags:
   - naming
   - branding
   - strategy
-repo: https://github.com/cc4marketing/naming-skill
+repo: https://github.com/cc4-marketing/naming-skill
 skillFile: naming.skill
 author: tri-vo
 draft: false

--- a/src/lib/og/build.ts
+++ b/src/lib/og/build.ts
@@ -163,6 +163,12 @@ const STATIC_PAGES: Record<
     accent: 'plum',
     badge: 'BRAND',
   },
+  skills: {
+    title: 'Claude Agent Skills',
+    subtitle: 'Curated Claude skills from the CC4 Marketing team — naming, brand voice, and more.',
+    accent: 'mustard',
+    badge: 'SKILLS',
+  },
 };
 
 async function main(): Promise<void> {

--- a/src/lib/og/url.ts
+++ b/src/lib/og/url.ts
@@ -20,7 +20,8 @@ export type OgPageKey =
   | 'changelog'
   | 'authors'
   | 'download'
-  | 'brand-guide';
+  | 'brand-guide'
+  | 'skills';
 
 const STATIC_FALLBACK_BLOG = '/og-blog.png';
 const STATIC_FALLBACK_DEFAULT = '/og-image.png';

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -1,0 +1,24 @@
+import { getCollection, type CollectionEntry } from 'astro:content';
+
+export type SkillEntry = CollectionEntry<'skills'>;
+
+/** Slug for a skill entry — the filename without extension or directory. */
+export function skillSlug(entry: SkillEntry): string {
+  return entry.id.replace(/\.md$/, '').split('/').pop() ?? entry.id;
+}
+
+/** All published (non-draft) skills, newest first; ties broken by name. */
+export async function getPublishedSkills(): Promise<SkillEntry[]> {
+  return (await getCollection('skills'))
+    .filter((s) => !s.data.draft)
+    .toSorted((a, b) => {
+      const byDate = b.data.publishedAt.getTime() - a.data.publishedAt.getTime();
+      return byDate !== 0 ? byDate : a.data.name.localeCompare(b.data.name);
+    });
+}
+
+/** Look up a single published skill by slug, or null if absent/draft. */
+export async function getSkillBySlug(slug: string): Promise<SkillEntry | null> {
+  const skills = await getCollection('skills');
+  return skills.find((e) => skillSlug(e) === slug && !e.data.draft) ?? null;
+}

--- a/src/pages/skills/[slug].astro
+++ b/src/pages/skills/[slug].astro
@@ -1,0 +1,338 @@
+---
+export const prerender = false;
+
+import { getCollection, render } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+
+const { slug } = Astro.params;
+
+const skills = await getCollection('skills');
+const entry = skills.find((e) => e.id.replace(/\.md$/, '') === slug && !e.data.draft);
+
+if (!entry) {
+  return Astro.redirect('/404');
+}
+
+const { Content } = await render(entry);
+const { name, description, tags, repo, skillFile, publishedAt, updatedAt } = entry.data;
+
+const pageUrl = `https://cc4.marketing/skills/${slug}/`;
+const downloadUrl = skillFile ? `/skills/${slug}/download.skill` : null;
+
+const softwareSchema = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name,
+  description,
+  url: pageUrl,
+  applicationCategory: "DeveloperApplication",
+  operatingSystem: "Claude Code",
+  offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+  ...(repo ? { codeRepository: repo } : {}),
+  datePublished: publishedAt.toISOString(),
+  ...(updatedAt ? { dateModified: updatedAt.toISOString() } : {}),
+  publisher: { "@type": "Organization", name: "CC4.Marketing", url: "https://cc4.marketing/" },
+};
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    { "@type": "ListItem", position: 1, name: "Home", item: "https://cc4.marketing/" },
+    { "@type": "ListItem", position: 2, name: "Skills", item: "https://cc4.marketing/skills/" },
+    { "@type": "ListItem", position: 3, name, item: pageUrl },
+  ],
+};
+---
+
+<BaseLayout
+  title={`${name} | Claude Code for Marketers`}
+  description={description}
+  keywords={tags}
+  ogPageKey="skills"
+  showCourseSchema={false}
+  showBreadcrumb={false}
+>
+  <Header />
+
+  <script type="application/ld+json" set:html={JSON.stringify(softwareSchema)} />
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
+
+  <article class="skill-detail">
+    <nav class="skill-breadcrumb" aria-label="Breadcrumb">
+      <a href="/skills/">Skills</a> <span aria-hidden="true">/</span> <span>{name}</span>
+    </nav>
+
+    <header class="skill-header">
+      <h1 class="skill-title">{name}</h1>
+      <p class="skill-desc">{description}</p>
+      {tags && tags.length > 0 && (
+        <ul class="skill-tags" aria-label="Tags">
+          {tags.map((tag) => <li class="skill-tag">{tag}</li>)}
+        </ul>
+      )}
+
+      <div class="skill-actions">
+        {repo && (
+          <a href={repo} target="_blank" rel="noopener" class="skill-action skill-action-primary">
+            View on GitHub
+          </a>
+        )}
+        {downloadUrl && (
+          <a href={downloadUrl} class="skill-action" download={`${slug}.skill`}>
+            Download .skill
+          </a>
+        )}
+      </div>
+    </header>
+
+    <section class="skill-install">
+      <h2>How to install</h2>
+      <ol>
+        <li>Download the <code>.skill</code> file above (or clone the GitHub repo).</li>
+        <li>Place it in your Claude Code skills directory: <code>~/.claude/skills/</code>.</li>
+        <li>Restart Claude Code. The skill is now available — invoke it by name.</li>
+      </ol>
+      {!downloadUrl && repo && (
+        <p class="skill-install-note">
+          A packaged download isn't available yet — grab the skill from
+          <a href={repo} target="_blank" rel="noopener"> the GitHub repo</a> instead.
+        </p>
+      )}
+    </section>
+
+    <section class="skill-readme">
+      <h2 class="skill-readme-heading">SKILL.md</h2>
+      <div class="skill-prose">
+        <Content />
+      </div>
+    </section>
+  </article>
+
+  <Footer />
+</BaseLayout>
+
+<style>
+  .skill-detail {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 120px 24px 80px;
+  }
+
+  .skill-breadcrumb {
+    font-size: 0.85em;
+    color: var(--text-secondary);
+    margin-bottom: 24px;
+  }
+
+  .skill-breadcrumb a {
+    color: var(--rust);
+    text-decoration: none;
+  }
+
+  .skill-breadcrumb a:hover {
+    text-decoration: underline;
+  }
+
+  .skill-header {
+    border-bottom: 2px solid var(--border-color);
+    padding-bottom: 32px;
+    margin-bottom: 32px;
+  }
+
+  .skill-title {
+    font-family: var(--font-display);
+    font-size: clamp(2em, 5vw, 3em);
+    color: var(--text-primary);
+    margin: 0 0 12px;
+    line-height: 1.1;
+  }
+
+  .skill-desc {
+    font-size: 1.15em;
+    color: var(--text-secondary);
+    line-height: 1.5;
+    margin: 0 0 16px;
+  }
+
+  .skill-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    list-style: none;
+    padding: 0;
+    margin: 0 0 24px;
+  }
+
+  .skill-tag {
+    font-size: 0.7em;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-secondary);
+    background: rgba(184, 92, 60, 0.08);
+    border: 1px solid var(--border-color);
+    padding: 3px 8px;
+  }
+
+  .skill-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .skill-action {
+    display: inline-block;
+    font-size: 0.9em;
+    font-weight: 600;
+    text-decoration: none;
+    color: var(--rust);
+    border: 2px solid var(--rust);
+    padding: 10px 22px;
+    transition: all 0.2s ease;
+  }
+
+  .skill-action:hover {
+    background: var(--rust);
+    color: var(--cream);
+  }
+
+  .skill-action-primary {
+    background: var(--rust);
+    color: var(--cream);
+  }
+
+  .skill-action-primary:hover {
+    background: var(--charcoal);
+    border-color: var(--charcoal);
+  }
+
+  .skill-install {
+    background: var(--bg-secondary);
+    border: 2px solid var(--border-color);
+    padding: 24px 28px;
+    margin-bottom: 48px;
+  }
+
+  .skill-install h2 {
+    font-family: var(--font-display);
+    font-size: 1.3em;
+    margin: 0 0 16px;
+    color: var(--text-primary);
+  }
+
+  .skill-install ol {
+    margin: 0;
+    padding-left: 20px;
+    color: var(--text-primary);
+    line-height: 1.7;
+  }
+
+  .skill-install code {
+    font-size: 0.85em;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    padding: 1px 6px;
+  }
+
+  .skill-install-note {
+    margin: 16px 0 0;
+    font-size: 0.9em;
+    color: var(--text-secondary);
+  }
+
+  .skill-install-note a {
+    color: var(--rust);
+  }
+
+  .skill-readme-heading {
+    font-family: var(--font-display);
+    font-size: 0.8em;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-secondary);
+    margin: 0 0 16px;
+  }
+
+  /* Rendered SKILL.md prose */
+  .skill-prose {
+    font-size: 1.05em;
+    line-height: 1.75;
+    color: var(--text-primary);
+  }
+
+  .skill-prose :global(h1) {
+    font-family: var(--font-display);
+    font-size: 1.8em;
+    margin: 0 0 20px;
+    color: var(--text-primary);
+    line-height: 1.2;
+  }
+
+  .skill-prose :global(h2) {
+    font-family: var(--font-display);
+    font-size: 1.5em;
+    margin: 40px 0 14px;
+    color: var(--text-primary);
+    line-height: 1.2;
+  }
+
+  .skill-prose :global(h3) {
+    font-family: var(--font-display);
+    font-size: 1.25em;
+    margin: 32px 0 12px;
+    color: var(--text-primary);
+  }
+
+  .skill-prose :global(p),
+  .skill-prose :global(ul),
+  .skill-prose :global(ol) {
+    margin: 0 0 20px;
+  }
+
+  .skill-prose :global(ul),
+  .skill-prose :global(ol) {
+    padding-left: 24px;
+  }
+
+  .skill-prose :global(li) {
+    margin-bottom: 8px;
+  }
+
+  .skill-prose :global(a) {
+    color: var(--rust);
+  }
+
+  .skill-prose :global(blockquote) {
+    border-left: 3px solid var(--rust);
+    padding-left: 16px;
+    margin: 0 0 20px;
+    color: var(--text-secondary);
+  }
+
+  .skill-prose :global(pre) {
+    background: var(--bg-secondary);
+    border: 2px solid var(--border-color);
+    padding: 16px;
+    overflow-x: auto;
+    margin: 0 0 20px;
+  }
+
+  .skill-prose :global(code) {
+    font-size: 0.9em;
+  }
+
+  .skill-prose :global(:not(pre) > code) {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    padding: 1px 6px;
+  }
+
+  @media (max-width: 768px) {
+    .skill-detail {
+      padding: 100px 20px 60px;
+    }
+  }
+</style>

--- a/src/pages/skills/[slug].astro
+++ b/src/pages/skills/[slug].astro
@@ -1,22 +1,22 @@
 ---
 export const prerender = false;
 
-import { getCollection, render } from 'astro:content';
+import { render } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
+import { getSkillBySlug } from '../../lib/skills';
 
 const { slug } = Astro.params;
 
-const skills = await getCollection('skills');
-const entry = skills.find((e) => e.id.replace(/\.md$/, '') === slug && !e.data.draft);
+const entry = await getSkillBySlug(slug ?? '');
 
 if (!entry) {
   return Astro.redirect('/404');
 }
 
 const { Content } = await render(entry);
-const { name, description, tags, repo, skillFile, publishedAt, updatedAt } = entry.data;
+const { name, description, tags, repo, skillFile, author, publishedAt, updatedAt } = entry.data;
 
 const pageUrl = `https://cc4.marketing/skills/${slug}/`;
 const downloadUrl = skillFile ? `/skills/${slug}/download.skill` : null;
@@ -30,6 +30,7 @@ const softwareSchema = {
   applicationCategory: "DeveloperApplication",
   operatingSystem: "Claude Code",
   offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+  ...(author ? { author: { "@type": "Person", name: author } } : {}),
   ...(repo ? { codeRepository: repo } : {}),
   datePublished: publishedAt.toISOString(),
   ...(updatedAt ? { dateModified: updatedAt.toISOString() } : {}),

--- a/src/pages/skills/[slug].astro
+++ b/src/pages/skills/[slug].astro
@@ -5,6 +5,7 @@ import { render } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
+import SkillCart from '../../components/SkillCart.astro';
 import { getSkillBySlug } from '../../lib/skills';
 
 const { slug } = Astro.params;
@@ -20,6 +21,9 @@ const { name, description, tags, repo, skillFile, author, publishedAt, updatedAt
 
 const pageUrl = `https://cc4.marketing/skills/${slug}/`;
 const downloadUrl = skillFile ? `/skills/${slug}/download.skill` : null;
+const cloneCommand = repo
+  ? `git clone ${repo} ~/.claude/skills/${slug}`
+  : null;
 
 const softwareSchema = {
   "@context": "https://schema.org",
@@ -81,26 +85,49 @@ const breadcrumbSchema = {
             View on GitHub
           </a>
         )}
-        {downloadUrl && (
-          <a href={downloadUrl} class="skill-action" download={`${slug}.skill`}>
-            Download .skill
-          </a>
-        )}
+        <button
+          type="button"
+          class="skill-action skill-add-btn"
+          data-skill-add
+          data-slug={slug}
+          data-name={name}
+          data-repo={repo}
+          data-skill-file={skillFile}
+          aria-pressed="false"
+        >
+          <span data-add-label>Add to stack</span>
+        </button>
       </div>
     </header>
 
-    <section class="skill-install">
-      <h2>How to install</h2>
-      <ol>
-        <li>Download the <code>.skill</code> file above (or clone the GitHub repo).</li>
-        <li>Place it in your Claude Code skills directory: <code>~/.claude/skills/</code>.</li>
-        <li>Restart Claude Code. The skill is now available — invoke it by name.</li>
-      </ol>
-      {!downloadUrl && repo && (
-        <p class="skill-install-note">
-          A packaged download isn't available yet — grab the skill from
-          <a href={repo} target="_blank" rel="noopener"> the GitHub repo</a> instead.
-        </p>
+    <section class="skill-install" data-install-panel>
+      <h2 class="skill-install-title">Install</h2>
+
+      <div class="skill-tabs" role="tablist" aria-label="Install methods">
+        {cloneCommand && (
+          <button type="button" class="skill-tab" role="tab" id="tab-clone" aria-controls="panel-clone" aria-selected="true" data-tab="clone">git clone</button>
+        )}
+        {downloadUrl && (
+          <button type="button" class="skill-tab" role="tab" id="tab-download" aria-controls="panel-download" aria-selected={cloneCommand ? 'false' : 'true'} data-tab="download">Download</button>
+        )}
+      </div>
+
+      {cloneCommand && (
+        <div class="skill-tabpanel" id="panel-clone" role="tabpanel" aria-labelledby="tab-clone" data-panel="clone">
+          <p class="skill-tabpanel-lead">Clone the skill straight into your Claude Code skills directory, then restart Claude Code.</p>
+          <pre><code>{cloneCommand}</code></pre>
+        </div>
+      )}
+
+      {downloadUrl && (
+        <div class="skill-tabpanel" id="panel-download" role="tabpanel" aria-labelledby="tab-download" data-panel="download" hidden={!!cloneCommand}>
+          <p class="skill-tabpanel-lead">Download the packaged skill, move it into <code>~/.claude/skills/</code>, then restart Claude Code.</p>
+          <a href={downloadUrl} class="skill-action skill-action-primary" download={`${slug}.skill`}>Download {slug}.skill</a>
+        </div>
+      )}
+
+      {!cloneCommand && !downloadUrl && (
+        <p class="skill-install-note">Install steps for this skill are coming soon.</p>
       )}
     </section>
 
@@ -112,8 +139,38 @@ const breadcrumbSchema = {
     </section>
   </article>
 
+  <SkillCart />
+
   <Footer />
 </BaseLayout>
+
+<script>
+  // Tabbed install panel: switch active tab/panel. Scoped to [data-install-panel].
+  function setupInstallTabs(): void {
+    document.querySelectorAll<HTMLElement>('[data-install-panel]').forEach((panel) => {
+      const tabs = panel.querySelectorAll<HTMLElement>('.skill-tab');
+      const panes = panel.querySelectorAll<HTMLElement>('.skill-tabpanel');
+      tabs.forEach((tab) => {
+        if (tab.dataset.tabBound) return;
+        tab.dataset.tabBound = '1';
+        tab.addEventListener('click', () => {
+          const target = tab.dataset.tab;
+          tabs.forEach((t) => t.setAttribute('aria-selected', String(t === tab)));
+          panes.forEach((p) => {
+            p.hidden = p.dataset.panel !== target;
+          });
+        });
+      });
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setupInstallTabs);
+  } else {
+    setupInstallTabs();
+  }
+  window.addEventListener('pageshow', setupInstallTabs);
+</script>
 
 <style>
   .skill-detail {
@@ -217,29 +274,92 @@ const breadcrumbSchema = {
     margin-bottom: 48px;
   }
 
-  .skill-install h2 {
+  .skill-add-btn {
+    cursor: pointer;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    border-color: var(--border-color);
+  }
+
+  .skill-add-btn:hover {
+    background: var(--bg-primary);
+    border-color: var(--rust);
+    color: var(--rust);
+  }
+
+  .skill-add-btn.in-stack {
+    background: var(--rust);
+    border-color: var(--rust);
+    color: var(--cream);
+  }
+
+  .skill-install-title {
     font-family: var(--font-display);
     font-size: 1.3em;
     margin: 0 0 16px;
     color: var(--text-primary);
   }
 
-  .skill-install ol {
+  .skill-tabs {
+    display: flex;
+    gap: 0;
+    margin-bottom: 16px;
+    border-bottom: 2px solid var(--border-color);
+  }
+
+  .skill-tab {
+    background: transparent;
+    border: none;
+    border-bottom: 3px solid transparent;
+    margin-bottom: -2px;
+    padding: 8px 16px;
+    font-size: 0.9em;
+    font-weight: 600;
+    color: var(--text-secondary);
+    cursor: pointer;
+  }
+
+  .skill-tab[aria-selected='true'] {
+    color: var(--rust);
+    border-bottom-color: var(--rust);
+  }
+
+  .skill-tabpanel-lead {
+    font-size: 0.9em;
+    color: var(--text-secondary);
+    margin: 0 0 12px;
+    line-height: 1.5;
+  }
+
+  .skill-install pre {
+    background: #1c1c1c;
+    color: #eaeaea;
+    border: 2px solid #2a2a2a;
+    padding: 16px;
+    overflow-x: auto;
     margin: 0;
-    padding-left: 20px;
-    color: var(--text-primary);
-    line-height: 1.7;
+    font-size: 0.85em;
+  }
+
+  .skill-install pre code {
+    color: inherit;
+    background: transparent;
+    border: none;
+    padding: 0;
   }
 
   .skill-install code {
     font-size: 0.85em;
+  }
+
+  .skill-tabpanel-lead code {
     background: var(--bg-primary);
     border: 1px solid var(--border-color);
     padding: 1px 6px;
   }
 
   .skill-install-note {
-    margin: 16px 0 0;
+    margin: 0;
     font-size: 0.9em;
     color: var(--text-secondary);
   }

--- a/src/pages/skills/[slug]/download.skill.ts
+++ b/src/pages/skills/[slug]/download.skill.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import { getCollection } from 'astro:content';
+import { getSkillBySlug } from '../../../lib/skills';
 
 export const prerender = false;
 
@@ -11,8 +11,7 @@ export const GET: APIRoute = async ({ params }) => {
 
   // Validate the slug against the known collection BEFORE building any R2 key —
   // this prevents arbitrary-key fetches / path traversal (e.g. ../../secret).
-  const skills = await getCollection('skills');
-  const entry = skills.find((e) => e.id.replace(/\.md$/, '') === slug && !e.data.draft);
+  const entry = await getSkillBySlug(slug);
 
   if (!entry || !entry.data.skillFile) {
     return notFound();

--- a/src/pages/skills/[slug]/download.skill.ts
+++ b/src/pages/skills/[slug]/download.skill.ts
@@ -1,0 +1,59 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+
+export const prerender = false;
+
+const NOT_FOUND_CACHE_CONTROL = 'public, max-age=300';
+const DOWNLOAD_CACHE_CONTROL = 'public, max-age=31536000, immutable';
+
+export const GET: APIRoute = async ({ params }) => {
+  const slug = params.slug ?? '';
+
+  // Validate the slug against the known collection BEFORE building any R2 key —
+  // this prevents arbitrary-key fetches / path traversal (e.g. ../../secret).
+  const skills = await getCollection('skills');
+  const entry = skills.find((e) => e.id.replace(/\.md$/, '') === slug && !e.data.draft);
+
+  if (!entry || !entry.data.skillFile) {
+    return notFound();
+  }
+
+  const { env } = await import('cloudflare:workers');
+  const media = (env as { MEDIA?: R2Bucket }).MEDIA;
+
+  // Local dev without an R2 binding — degrade gracefully rather than throw.
+  if (!media) {
+    return notFound('Download unavailable in this environment.');
+  }
+
+  // The skillFile value is a fixed string from validated frontmatter; the slug
+  // it pairs with has already been confirmed to exist in the collection.
+  const r2Key = `skills/${entry.data.skillFile}`;
+  const obj = await media.get(r2Key).catch(() => null);
+
+  if (!obj) {
+    return notFound();
+  }
+
+  const body = await obj.arrayBuffer();
+  return new Response(body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'Content-Disposition': `attachment; filename="${slug}.skill"`,
+      'Cache-Control': DOWNLOAD_CACHE_CONTROL,
+      'X-Robots-Tag': 'noindex',
+    },
+  });
+};
+
+function notFound(message = 'Skill download not found.'): Response {
+  return new Response(message, {
+    status: 404,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': NOT_FOUND_CACHE_CONTROL,
+      'X-Robots-Tag': 'noindex',
+    },
+  });
+}

--- a/src/pages/skills/index.astro
+++ b/src/pages/skills/index.astro
@@ -4,6 +4,7 @@ export const prerender = false;
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
+import SkillCart from '../../components/SkillCart.astro';
 import { getPublishedSkills, skillSlug } from '../../lib/skills';
 
 const skills = await getPublishedSkills();
@@ -64,26 +65,47 @@ const skills = await getPublishedSkills();
         </div>
       ) : (
         <div class="skills-grid">
-          {skills.map((skill) => (
-            <a href={`/skills/${skillSlug(skill)}/`} class="skill-card">
-              <div class="skill-card-body">
-                <h2 class="skill-card-title">{skill.data.name}</h2>
-                <p class="skill-card-desc">{skill.data.description}</p>
-                {skill.data.tags && skill.data.tags.length > 0 && (
-                  <ul class="skill-card-tags" aria-label="Tags">
-                    {skill.data.tags.map((tag) => (
-                      <li class="skill-tag">{tag}</li>
-                    ))}
-                  </ul>
-                )}
-                <span class="skill-card-link">View skill</span>
-              </div>
-            </a>
-          ))}
+          {skills.map((skill) => {
+            const slug = skillSlug(skill);
+            return (
+              <article class="skill-card">
+                <div class="skill-card-body">
+                  <h2 class="skill-card-title">
+                    <a href={`/skills/${slug}/`}>{skill.data.name}</a>
+                  </h2>
+                  <p class="skill-card-desc">{skill.data.description}</p>
+                  {skill.data.tags && skill.data.tags.length > 0 && (
+                    <ul class="skill-card-tags" aria-label="Tags">
+                      {skill.data.tags.map((tag) => (
+                        <li class="skill-tag">{tag}</li>
+                      ))}
+                    </ul>
+                  )}
+                  <div class="skill-card-actions">
+                    <a href={`/skills/${slug}/`} class="skill-card-link">View skill</a>
+                    <button
+                      type="button"
+                      class="skill-card-add"
+                      data-skill-add
+                      data-slug={slug}
+                      data-name={skill.data.name}
+                      data-repo={skill.data.repo}
+                      data-skill-file={skill.data.skillFile}
+                      aria-pressed="false"
+                    >
+                      <span data-add-label>Add to stack</span>
+                    </button>
+                  </div>
+                </div>
+              </article>
+            );
+          })}
         </div>
       )}
     </div>
   </section>
+
+  <SkillCart />
 
   <Footer />
 </BaseLayout>
@@ -212,6 +234,16 @@ const skills = await getPublishedSkills();
     color: var(--text-primary);
   }
 
+  .skill-card-title a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  /* Whole-card hover cue carries even though only the title is the link. */
+  .skill-card:hover .skill-card-title a {
+    color: var(--rust);
+  }
+
   .skill-card-desc {
     font-size: 0.9em;
     color: var(--text-secondary);
@@ -240,15 +272,47 @@ const skills = await getPublishedSkills();
     padding: 3px 8px;
   }
 
+  .skill-card-actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-top: auto;
+    padding-top: 4px;
+  }
+
   .skill-card-link {
     font-size: 0.85em;
     font-weight: 600;
     color: var(--rust);
-    margin-top: auto;
+    text-decoration: none;
   }
 
-  .skill-card:hover .skill-card-link {
+  .skill-card-link:hover {
     text-decoration: underline;
+  }
+
+  .skill-card-add {
+    font-size: 0.8em;
+    font-weight: 600;
+    color: var(--text-primary);
+    background: var(--bg-primary);
+    border: 2px solid var(--border-color);
+    padding: 6px 12px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    white-space: nowrap;
+  }
+
+  .skill-card-add:hover {
+    border-color: var(--rust);
+    color: var(--rust);
+  }
+
+  .skill-card-add.in-stack {
+    background: var(--rust);
+    border-color: var(--rust);
+    color: var(--cream);
   }
 
   @media (max-width: 768px) {

--- a/src/pages/skills/index.astro
+++ b/src/pages/skills/index.astro
@@ -1,0 +1,280 @@
+---
+export const prerender = false;
+
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+
+const skills = (await getCollection('skills'))
+  .filter((s) => !s.data.draft)
+  .toSorted((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
+
+function slugOf(id: string): string {
+  return id.replace(/\.md$/, '');
+}
+---
+
+<BaseLayout
+  title="Skills — Claude Agent Skills for Marketers"
+  description="Curated Claude agent skills from the CC4 Marketing team — naming, brand voice, and content workflows. Read the SKILL.md, grab the source, or download the packaged skill."
+  keywords={['Claude agent skills', 'Claude Code skills', 'marketing skills', 'SKILL.md', 'AI marketing tools']}
+  ogPageKey="skills"
+  noindex={skills.length === 0}
+  showCourseSchema={false}
+  showBreadcrumb={false}
+>
+  <Header />
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://cc4.marketing/" },
+      { "@type": "ListItem", "position": 2, "name": "Skills", "item": "https://cc4.marketing/skills/" }
+    ]
+  })} />
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": "CC4.Marketing Skills",
+    "description": "Curated Claude agent skills from the CC4 Marketing team.",
+    "url": "https://cc4.marketing/skills/",
+    "isPartOf": { "@type": "WebSite", "name": "CC4.Marketing", "url": "https://cc4.marketing/" },
+    "publisher": { "@type": "Organization", "name": "CC4.Marketing", "url": "https://cc4.marketing/" },
+    "breadcrumb": {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://cc4.marketing/" },
+        { "@type": "ListItem", "position": 2, "name": "Skills", "item": "https://cc4.marketing/skills/" }
+      ]
+    }
+  })} />
+
+  <section class="skills-hero">
+    <div class="skills-hero-pattern"></div>
+    <div class="skills-hero-inner">
+      <span class="skills-hero-label">Claude Agent Skills</span>
+      <h1 class="skills-hero-title">Skills</h1>
+      <p class="skills-hero-desc">Curated Claude agent skills from the CC4 Marketing team. Read the SKILL.md, grab the source, or download the packaged skill.</p>
+    </div>
+  </section>
+
+  <section class="skills-body">
+    <div class="skills-body-inner">
+      {skills.length === 0 ? (
+        <div class="skills-empty">
+          <h3>Coming soon</h3>
+          <p>We're packaging our first skills. Check back shortly.</p>
+        </div>
+      ) : (
+        <div class="skills-grid">
+          {skills.map((skill) => (
+            <a href={`/skills/${slugOf(skill.id)}/`} class="skill-card">
+              <div class="skill-card-body">
+                <h2 class="skill-card-title">{skill.data.name}</h2>
+                <p class="skill-card-desc">{skill.data.description}</p>
+                {skill.data.tags && skill.data.tags.length > 0 && (
+                  <ul class="skill-card-tags" aria-label="Tags">
+                    {skill.data.tags.map((tag) => (
+                      <li class="skill-tag">{tag}</li>
+                    ))}
+                  </ul>
+                )}
+                <span class="skill-card-link">View skill</span>
+              </div>
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  </section>
+
+  <Footer />
+</BaseLayout>
+
+<style>
+  /* Hero */
+  .skills-hero {
+    position: relative;
+    padding: 140px 24px 60px;
+    text-align: center;
+    overflow: hidden;
+    background: linear-gradient(135deg, var(--bg-primary) 0%, rgba(184, 92, 60, 0.06) 100%);
+  }
+
+  .skills-hero-pattern {
+    position: absolute;
+    inset: 0;
+    opacity: 0.03;
+    background-image: radial-gradient(circle at 1px 1px, var(--charcoal) 1px, transparent 0);
+    background-size: 40px 40px;
+    pointer-events: none;
+  }
+
+  .skills-hero-inner {
+    position: relative;
+    max-width: 700px;
+    margin: 0 auto;
+  }
+
+  .skills-hero-label {
+    display: inline-block;
+    font-size: 0.75em;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    color: var(--rust);
+    background: rgba(184, 92, 60, 0.1);
+    padding: 6px 14px;
+    margin-bottom: 20px;
+  }
+
+  .skills-hero-title {
+    font-family: var(--font-display);
+    font-size: clamp(2.5em, 6vw, 4em);
+    color: var(--text-primary);
+    margin: 0 0 16px;
+    line-height: 1.1;
+  }
+
+  .skills-hero-desc {
+    font-size: 1.15em;
+    color: var(--text-secondary);
+    max-width: 540px;
+    margin: 0 auto;
+    line-height: 1.5;
+  }
+
+  /* Body */
+  .skills-body {
+    padding: 60px 24px 100px;
+  }
+
+  .skills-body-inner {
+    max-width: 960px;
+    margin: 0 auto;
+  }
+
+  /* Empty state */
+  .skills-empty {
+    text-align: center;
+    padding: 80px 24px;
+    border: 2px dashed var(--border-color);
+  }
+
+  .skills-empty h3 {
+    font-family: var(--font-display);
+    font-size: 1.5em;
+    color: var(--rust);
+    margin: 0 0 12px;
+  }
+
+  .skills-empty p {
+    color: var(--text-secondary);
+    font-size: 1em;
+  }
+
+  /* Grid — auto-fill with a max column count so 1–2 cards left-align
+     instead of stretching across the full row. */
+  .skills-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 320px));
+    gap: 32px;
+    justify-content: start;
+  }
+
+  /* Card */
+  .skill-card {
+    display: flex;
+    flex-direction: column;
+    border: 2px solid var(--border-color);
+    background: var(--bg-secondary);
+    text-decoration: none;
+    color: var(--text-primary);
+    transition: all 0.25s ease;
+    box-shadow: var(--shadow-sm);
+  }
+
+  .skill-card:hover {
+    transform: translate(-4px, -4px);
+    box-shadow: 8px 8px 0 var(--mustard);
+    border-color: var(--rust);
+  }
+
+  .skill-card-body {
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+  }
+
+  .skill-card-title {
+    font-family: var(--font-display);
+    font-size: 1.3em;
+    margin: 0 0 10px;
+    line-height: 1.25;
+    color: var(--text-primary);
+  }
+
+  .skill-card-desc {
+    font-size: 0.9em;
+    color: var(--text-secondary);
+    line-height: 1.5;
+    flex: 1;
+    margin: 0 0 16px;
+  }
+
+  .skill-card-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    list-style: none;
+    padding: 0;
+    margin: 0 0 16px;
+  }
+
+  .skill-tag {
+    font-size: 0.7em;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-secondary);
+    background: rgba(184, 92, 60, 0.08);
+    border: 1px solid var(--border-color);
+    padding: 3px 8px;
+  }
+
+  .skill-card-link {
+    font-size: 0.85em;
+    font-weight: 600;
+    color: var(--rust);
+    margin-top: auto;
+  }
+
+  .skill-card:hover .skill-card-link {
+    text-decoration: underline;
+  }
+
+  @media (max-width: 768px) {
+    .skills-hero {
+      padding: 120px 20px 40px;
+    }
+
+    .skills-grid {
+      grid-template-columns: 1fr;
+      gap: 24px;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .skill-card {
+      transition: none;
+    }
+
+    .skill-card:hover {
+      transform: none;
+    }
+  }
+</style>

--- a/src/pages/skills/index.astro
+++ b/src/pages/skills/index.astro
@@ -1,18 +1,12 @@
 ---
 export const prerender = false;
 
-import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
+import { getPublishedSkills, skillSlug } from '../../lib/skills';
 
-const skills = (await getCollection('skills'))
-  .filter((s) => !s.data.draft)
-  .toSorted((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
-
-function slugOf(id: string): string {
-  return id.replace(/\.md$/, '');
-}
+const skills = await getPublishedSkills();
 ---
 
 <BaseLayout
@@ -71,7 +65,7 @@ function slugOf(id: string): string {
       ) : (
         <div class="skills-grid">
           {skills.map((skill) => (
-            <a href={`/skills/${slugOf(skill.id)}/`} class="skill-card">
+            <a href={`/skills/${skillSlug(skill)}/`} class="skill-card">
               <div class="skill-card-body">
                 <h2 class="skill-card-title">{skill.data.name}</h2>
                 <p class="skill-card-desc">{skill.data.description}</p>


### PR DESCRIPTION
## Summary
A new `/skills` gallery sharing CC4M's own Claude agent skills (SKILL.md bundles), in the spirit of [kits.vibery.app](https://kits.vibery.app/).

- **Index** (`/skills/`) — card grid (name, description, tags) with an **"Add to stack"** button per card
- **Detail** (`/skills/<slug>/`) — GitHub link, **tabbed install** (git clone / Download), inline-rendered SKILL.md, `SoftwareApplication` + `BreadcrumbList` JSON-LD
- **Stack cart** (Vibery-style buffet) — select multiple skills, persistent tray, checkout panel emits one combined `git clone … ~/.claude/skills/<slug>` block + a `.skill` download list. localStorage-backed, persists across navigation, syncs across tabs
- **Download route** — R2-backed (`MEDIA` binding) via SSR, slug-validated (traversal-safe), 404-not-500 on miss, `noindex`
- **Wiring** — `skills` Content Collection (SSR, `prerender=false`), OG `skills` page key, sitemap `skillPages` + serialize branch, `llms.txt`/`llms-full.txt`, header nav entry

Content-Collection-under-SSR was de-risked with a Phase-1 spike (verified in the workerd runtime that Emdash middleware doesn't hijack `/skills/*`).

## Testing
- 37/37 unit tests pass; clean `npm run build`
- Smoke-tested in `wrangler dev --local` (workerd): index/detail 200, unknown slug → 404, download 404-not-500, draft exclusion, blog regression clean
- Cart flow driven end-to-end (add → checkout → combined script); verified `[hidden]` override fix and copy-button-collision fix visually

Two placeholder skills ship for layout; real SKILL.md content + `.skill` R2 uploads land separately.

## Post-Deploy Monitoring & Validation
- **What to monitor**: Cloudflare Workers logs for `/skills/*` (5xx rate), and that `/skills/<slug>/download.skill` returns 404 (not 500) until `.skill` files are uploaded to R2
- **Validation**: `curl -I https://cc4.marketing/skills/` → 200; `curl https://cc4.marketing/sitemap-0.xml | grep skills` → 3 URLs; Google Rich Results Test on a detail page (SoftwareApplication valid)
- **Healthy signals**: `/skills/` and `/skills/<slug>/` 200; OG `og/pages/skills.png` present; no `/_emdash/admin/setup` redirects on `/skills/*`
- **Failure signal / rollback**: any `/skills/*` 5xx or setup-redirect → revert this PR (gallery is additive; no data migration)
- **Window & owner**: first 24h post-merge, @blacklogos
- Re-run `/seo-audit` after deploy; confirm `robots.txt` has no Cloudflare-managed AI-bot block

## Follow-ups (not in this PR)
- Replace placeholder SKILL.md content with the real skills
- Upload `.skill` files to R2 (`wrangler r2 object put cc4-media skills/<slug>.skill ...`)
- Add the `/plugin marketplace add` install tab once a CC4M marketplace exists

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)