### PR TITLE
Phase 0: reconcile lesson count to 19 + auto-sync llms on publish

### DIFF
--- a/.claude/skills/publish-post/SKILL.md
+++ b/.claude/skills/publish-post/SKILL.md
@@ -134,23 +134,17 @@ If no bespoke cover exists, `featured_image` can stay null — the OG engine han
 > sips --cropToHeightWidth 630 1200 /tmp/tmp.png --out public/blog/cover-{slug}.png
 > ```
 
-### Step 5b: Update llms.txt and llms-full.txt
+### Step 5b: Update llms.txt and llms-full.txt (automatic)
 
-Both files must be updated so AI crawlers (Perplexity, Claude, etc.) can discover the new post.
+Both files feed AI crawlers (Perplexity, Claude, etc.) so they discover the new post.
 
-**`public/llms.txt`** — append to the `### Published Posts` section:
+`publish_post.py` now updates both automatically on `--execute` (right after the sitemap step), reusing the frontmatter `excerpt`:
+- `public/llms.txt` gets `- [{title}]({url})`.
+- `public/llms-full.txt` gets `- [{title}]({url}) ({excerpt})`.
 
-```markdown
-- [{Post Title}](https://cc4.marketing/blog/{slug}/)
-```
+Both inserts are idempotent (skip if the post URL is already present), so re-running is safe. No manual edit needed.
 
-**`public/llms-full.txt`** — append to the `### Published Posts` section with a one-sentence description:
-
-```markdown
-- [{Post Title}](https://cc4.marketing/blog/{slug}/) — {one-sentence description of the post's topic and value}
-```
-
-Stage both files alongside the cover PNG so they ship in the same commit.
+Verify after running: confirm the two new lines landed (`git diff public/llms.txt public/llms-full.txt`). If `--skip-sitemap` was passed, the llms update is skipped too; add the lines by hand or re-run without the flag. Stage both files alongside the cover PNG so they ship in the same commit.
 
 ### Step 6: Ship
 

--- a/.claude/skills/publish-post/publish_post.py
+++ b/.claude/skills/publish-post/publish_post.py
@@ -56,6 +56,9 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parents[3]
 ASTRO_CONFIG = REPO_ROOT / "astro.config.mjs"
 PUBLIC_BLOG = REPO_ROOT / "public" / "blog"
+LLMS_TXT = REPO_ROOT / "public" / "llms.txt"
+LLMS_FULL_TXT = REPO_ROOT / "public" / "llms-full.txt"
+SITE_ORIGIN = "https://cc4.marketing"
 
 
 # ---------- ID / key generation -------------------------------------------
@@ -526,6 +529,63 @@ def update_sitemap(slug: str) -> None:
     print(f"sitemap: added /blog/{slug} to blogPages")
 
 
+def _append_to_published_posts(path: Path, entry_line: str, url: str) -> None:
+    """Append entry_line under the '### Published Posts' section of an llms file.
+
+    Idempotent: skips if the post url is already present. Inserts at the end of
+    the existing list (matches the oldest-first order the files already use),
+    right before the next section marker ('## ' or '---').
+    """
+    if not path.exists():
+        print(f"llms: {path.name} not found, skipping", file=sys.stderr)
+        return
+    text = path.read_text()
+    if url in text:
+        print(f"llms: {url} already in {path.name}, skipping")
+        return
+
+    lines = text.splitlines()
+    try:
+        header_idx = next(
+            i for i, ln in enumerate(lines) if ln.strip() == "### Published Posts"
+        )
+    except StopIteration:
+        print(
+            f"llms: '### Published Posts' not found in {path.name}, skipping",
+            file=sys.stderr,
+        )
+        return
+
+    # Find the next section marker after the header; the list ends before it.
+    insert_idx = len(lines)
+    for i in range(header_idx + 1, len(lines)):
+        stripped = lines[i].lstrip()
+        if stripped.startswith("## ") or stripped.startswith("---"):
+            insert_idx = i
+            break
+    # Back up over blank lines so the new entry sits flush under the last item.
+    while insert_idx > header_idx + 1 and lines[insert_idx - 1].strip() == "":
+        insert_idx -= 1
+
+    lines.insert(insert_idx, entry_line)
+    path.write_text("\n".join(lines) + ("\n" if text.endswith("\n") else ""))
+    print(f"llms: added {url} to {path.name}")
+
+
+def update_llms_files(slug: str, title: str, excerpt: str) -> None:
+    """Add the new post to public/llms.txt and public/llms-full.txt so AI
+    discoverability stays in sync without a manual edit. llms.txt gets a plain
+    link; llms-full.txt appends the excerpt in parentheses (no em dash, per
+    house style). Both idempotent.
+    """
+    url = f"{SITE_ORIGIN}/blog/{slug}/"
+    _append_to_published_posts(LLMS_TXT, f"- [{title}]({url})", url)
+    excerpt_clean = excerpt.strip().rstrip(".")
+    _append_to_published_posts(
+        LLMS_FULL_TXT, f"- [{title}]({url}) ({excerpt_clean})", url
+    )
+
+
 # ---------- SQL generation -------------------------------------------------
 
 def sql_escape(s: str) -> str:
@@ -714,6 +774,7 @@ def main() -> int:
 
     if not args.skip_sitemap:
         update_sitemap(record.slug)
+        update_llms_files(record.slug, record.title, record.excerpt)
 
     return 0
 

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ public/og/
 
 # Local Claude Code scheduling lock
 .claude/scheduled_tasks.lock
+
+# Python bytecode cache (publish-post helper)
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The website for **Claude Code for Marketers** — a free, interactive course tha
 
 ## What is this?
 
-This repo powers the course website at [cc4.marketing](https://cc4.marketing). It serves course documentation, 17 interactive lesson pages, and a live changelog. The actual course is taught inside [Claude Code](https://claude.ai/code) itself — students clone the [course repo](https://github.com/cc4-marketing/cc4.marketing), open Claude Code, and type `/start-0-0` to begin.
+This repo powers the course website at [cc4.marketing](https://cc4.marketing). It serves course documentation, 19 interactive lesson pages, and a live changelog. The actual course is taught inside [Claude Code](https://claude.ai/code) itself — students clone the [course repo](https://github.com/cc4-marketing/cc4.marketing), open Claude Code, and type `/start-0-0` to begin.
 
 ## Tech Stack
 
@@ -24,7 +24,7 @@ src/
 ├── pages/              # Routes (index, changelog, download, modules)
 ├── layouts/            # BaseLayout, LessonLayout
 ├── components/         # Header, Footer, Hero, WhatsNew, ModuleUpdatesBanner, etc.
-├── content/modules/    # 17 MDX lesson files across 3 modules
+├── content/modules/    # 19 MDX lesson files across 4 modules
 ├── config/             # siteData.ts (centralized site config)
 └── styles/             # global.css (design system)
 changelog-worker/       # Cloudflare Worker for changelog API
@@ -37,7 +37,8 @@ public/                 # Static assets, robots.txt, llms.txt
 |--------|-------|---------|----------|
 | 0 | Getting Started | 4 | ~30 min |
 | 1 | Core Concepts | 7 | ~3-4 hrs |
-| 2 | Advanced Applications | 6 | ~4-5 hrs |
+| 2 | Advanced Applications | 7 | ~4-5 hrs |
+| 3 | Capstone | 1 | ~75 min |
 
 ## Development
 

--- a/plans/20260718-0100-content-growth-strategy/first-tutorial-draft.md
+++ b/plans/20260718-0100-content-growth-strategy/first-tutorial-draft.md
@@ -1,0 +1,79 @@
+---
+title: "How to Write an SEO Content Brief with Claude Code"
+slug: seo-content-brief-with-claude-code
+excerpt: "Turn one keyword into a full SEO content brief in Claude Code with a reusable slash command. Intent, SERP notes, outline, entities, word count."
+author: tri-vo
+keywords: [seo content brief, claude code, content brief template, seo workflow]
+---
+
+A content brief is the difference between a writer guessing and a writer executing. Most briefs take 30 to 45 minutes of tab-switching: check the SERP, skim three competitors, note the intent, sketch an outline, list the entities. This tutorial turns that into one command you type once and reuse for every keyword.
+
+By the end you will have a `/content-brief` slash command in Claude Code that takes a target keyword and returns intent, SERP notes, a title, an outline, entities, internal links, and a grounded word count.
+
+## What you need
+
+Claude Code installed and a project folder open. If you have not set it up yet, the [installation lesson](https://cc4.marketing/modules/0/installation/) walks through it in five minutes. No coding required: you type plain English and save one text file.
+
+## Step 1: Create the command file
+
+Slash commands in Claude Code are just markdown files in `.claude/commands/`. Create one called `content-brief.md`:
+
+```markdown
+---
+description: Build a full SEO content brief from one target keyword.
+argument-hint: [target keyword]
+---
+
+You are an SEO strategist writing a content brief for a writer who has not
+researched this topic. The target keyword is: $ARGUMENTS
+
+Produce a brief with these sections, in this order:
+
+1. Target keyword and 3 to 5 secondary keywords or close variants.
+2. Search intent: label it informational, commercial, transactional, or
+   navigational, and explain in one sentence what the searcher wants.
+3. SERP notes: describe the likely content types ranking now, the common
+   angle, and one gap none of them cover.
+4. Recommended title and one-line meta description.
+5. Outline: an H2 and H3 structure that covers the topic more completely than
+   a typical top result. Mark which sections answer the primary intent.
+6. Entities and subtopics to include. List 8 to 12.
+7. Internal links: 3 to 5 types of pages that should link to or from this article.
+8. Target word count, with a one-line rationale tied to the SERP.
+9. Three questions the article must answer to earn a featured snippet.
+
+Keep it scannable. Use lists, not paragraphs, wherever possible. If the keyword
+is ambiguous, state your assumption at the top and continue.
+```
+
+## Step 2: Run it on a real keyword
+
+In Claude Code, type `/content-brief best crm for small teams` and swap in your own keyword. Claude returns the full brief in one pass.
+
+## Step 3: Read intent and SERP notes first
+
+If the intent label is wrong, the rest of the brief is built on sand. Refine the keyword (add a qualifier, narrow the audience) and rerun before you trust the outline.
+
+## Step 4: Hand off or keep going
+
+Give the outline and entity list to your writer, or stay in Claude Code and draft the article section by section against the brief. Because the structure is fixed, every brief your team produces looks the same, which makes drafting and review faster.
+
+## Example output
+
+For "best crm for small teams" the command labels the intent commercial, flags that the SERP is dominated by listicles with the same ten tools, and suggests the gap: none segment by team size under ten. The outline leads with that segmentation, and the word count lands around 2,200 with a rationale tied to the depth of the top three results.
+
+## Take it further
+
+- Grab the ready-made version on the [Content Brief Generator](https://cc4.marketing/library/seo/content-brief-generator/) page in the Marketing Library.
+- Pair it with the [Meta Title and Description Writer](https://cc4.marketing/library/seo/meta-title-description-writer/) to finish the on-page setup.
+- Learn the full method in the [Content Strategy lesson](https://cc4.marketing/modules/2/content-strategy/).
+
+## FAQ
+
+**Do I need to know how to code?** No. A slash command is a plain text file with instructions. You write instructions in English and save the file.
+
+**Where does the file go?** In `.claude/commands/content-brief.md` inside your project folder. Claude Code picks it up automatically.
+
+**Is the command free?** Yes. The full artifact lives in the Marketing Library at no cost. You only need your own Claude subscription to run it.
+
+**What pairs well with this?** The SERP intent classifier for keyword lists, and the meta title and description writer for the on-page tags.

--- a/plans/20260718-0100-content-growth-strategy/phase-00-debt-cleanup.md
+++ b/plans/20260718-0100-content-growth-strategy/phase-00-debt-cleanup.md
@@ -1,0 +1,217 @@
+# Phase 00 — Debt Cleanup / Foundation Prep
+
+Prep before content+growth push. Read-only findings below turned into concrete tasks.
+Each task: what + file + why. Do not gold-plate. Ship small, verify each.
+
+Business context: course free (top-of-funnel), monetize skill packs + flows at $19.99 via
+Polar (MoR). Substack = nurture newsletter. Resend = transactional only (welcome + download).
+
+---
+
+## Task 1 — Sitemap route collision (Emdash vs file route)
+
+Problem: `src/pages/sitemap.xml.ts` (line 10) is a file route that 301-redirects to
+`/sitemap-index.xml` (the real @astrojs/sitemap output). Emdash's astro integration
+(`astro.config.mjs` lines 162-165) injects its own `sitemap.xml` route that renders an empty
+`<urlset>` because D1 is not queryable at build. Two routes claim `/sitemap.xml`. Astro logs a
+route-collision warning today, will hard-error in a future major (noted in the file header,
+lines 5-7).
+
+Fix options:
+- A. Disable Emdash's injected sitemap via its integration options (preferred if it exists,
+  e.g. `emdash({ sitemap: false, ... })`). Then the file route owns `/sitemap.xml` cleanly, no
+  collision. Could not confirm the option name (node_modules read blocked). Verify against
+  installed `emdash/astro` types before relying on it.
+- B. If Emdash has no disable flag: keep the file route but silence/accept the warning. Fragile,
+  breaks on the next Emdash/Astro major. Not recommended as the end state.
+- C. Rename the real sitemap so nothing competes for `/sitemap.xml`. More churn (robots.txt +
+  Search Console resubmit). Avoid.
+
+Pick: A. Fallback to B only if A is not offered upstream.
+
+Steps:
+1. Grep the installed `emdash/astro` integration types for a sitemap/route toggle. If present,
+   add it in `astro.config.mjs` lines 162-165.
+2. If Emdash sitemap disabled: keep `src/pages/sitemap.xml.ts` redirect as-is (it becomes the
+   sole owner). If it can't be disabled: leave both, update the header comment in
+   `src/pages/sitemap.xml.ts` with the confirmed upstream status and a tracking note.
+3. Build (`npm run build`), confirm no collision warning in Astro output.
+4. Curl `https://cc4.marketing/sitemap.xml` post-deploy: must 301 to `/sitemap-index.xml`.
+
+Why: remove a known future-breaking warning before piling on content that grows the sitemap.
+
+---
+
+## Task 2 — Lesson-count inconsistency (pick a canonical number)
+
+Ground truth on disk (`src/content/modules/`): 19 MDX files.
+- module-0: 4 files (0.0-introduction, 0.1-installation, 0.2-start-clone, 0.3-github-pr-guide)
+- module-1: 7 files (1.1 … 1.7)
+- module-2: 7 files (2.1 … 2.7)
+- module-3: 1 file (3.1-ship-with-sigil)
+
+`0.3-github-pr-guide` is a supplementary guide, not a core numbered lesson. It inflates Module 0.
+
+Current surfaces disagree:
+| Surface | File | Says |
+|---|---|---|
+| README intro | `README.md:9` | "17 interactive lesson pages" |
+| README structure | `README.md:27` | "17 MDX lesson files across 3 modules" (also wrong: 4 modules) |
+| README table | `README.md:36-40` | M0=4, M1=7, M2=6; no Module 3 row |
+| siteData M0 | `src/config/siteData.ts:36` | "4 Lessons" (but only 3 titles listed line 37) |
+| siteData M2 | `src/config/siteData.ts:52` | "7 Lessons" |
+| FAQ answers | `src/pages/faq.astro:12,20,53,64` | "18 lessons", M0=3, M1=7, M2=7, +Capstone |
+| llms.txt | `public/llms.txt:3,35-38` | "18 lessons", M0=4, M1=7, M2=6, M3=1 |
+
+Canonical decision (owner-confirmed 2026-07-18): **4 modules, 19 lessons.** Count
+`0.3-github-pr-guide` as a real lesson. Distribution: M0=4, M1=7, M2=7, M3=1 = 19. Matches disk
+1:1 (19 MDX = 19 lessons), simplest mental model, no "core vs bonus" caveat to maintain.
+
+Reconcile every surface to "4 modules, 19 lessons":
+1. `README.md:9` — "17 interactive lesson pages" → "19".
+2. `README.md:27` — "17 MDX lesson files across 3 modules" → "19 MDX lesson files across 4
+   modules".
+3. `README.md:36-40` — fix table: M0=4 (keep), M2 6→7, add Module 3 (Capstone, 1, ~75 min) row.
+   Total row = 19.
+4. `src/config/siteData.ts:36-37` — Module 0 header already "4 Lessons" but `lessons` array lists
+   only 3 titles: add `0.3-github-pr-guide` as the 4th title so header and list agree.
+5. `src/config/siteData.ts:52` — Module 2 already "7 Lessons", verify the 7 titles present.
+6. `src/pages/faq.astro:12,20,53,64` — "18 lessons" → "19"; Module 0 "3 lessons" → "4".
+7. `public/llms.txt:3` — "18 lessons" → "19". `:35` Module 0 "(4 lessons...)" keep. `:37`
+   Module 2 "(6 lessons...)" → "(7 lessons...)", add service-package-from-engagement topic.
+8. `public/llms-full.txt` — same "18"→"19" + Module 2 6→7 edits (grep first).
+
+Why: AI answer engines and human readers get one consistent number. 19 = disk truth, zero
+ambiguity, every surface reconciles to the same figure.
+
+---
+
+## Task 3 — Auto-sync llms.txt / llms-full.txt in publish-post skill
+
+Today Step 5b of `.claude/skills/publish-post/SKILL.md` (lines 137-153) is a manual instruction:
+hand-append the new post to both files' `### Published Posts` section. Easy to forget, drifts.
+
+Both target files exist and have the section:
+- `public/llms.txt` — flat list `- [Title](url)`.
+- `public/llms-full.txt:12` — `### Published Posts`, list `- [Title](url) — description`.
+
+Automate inside the existing helper `publish_post.py` (referenced SKILL.md line 225), which
+already parses frontmatter (title, slug, excerpt) and appends to `blogPages` in
+`astro.config.mjs` (line 107). Extend it to also, on `--execute`:
+1. Read `public/llms.txt`, if `/blog/{slug}/` not already present, insert
+   `- [{title}](https://cc4.marketing/blog/{slug}/)` under `### Published Posts`.
+2. Read `public/llms-full.txt`, same, appending ` — {excerpt}` (reuse frontmatter excerpt as the
+   one-line description; no new field needed).
+3. Idempotent: skip if the slug line already exists (safe re-run).
+
+Then edit `SKILL.md`:
+- Step 5b (lines 137-153): change from "manually append" to "the helper appends both files on
+  --execute; verify the two lines landed."
+- Step 6 staging note (line 159) and Safety rule (line 219): keep "stage both files" but note
+  they're now auto-written, so `git add` picks them up.
+
+Why: removes a manual step that silently breaks AI discoverability when skipped. Excerpt already
+captured, so no extra input.
+
+---
+
+## Task 4 — Polar integration prep (plan only, no implementation)
+
+Skill present: `~/.claude/skills/payment-integration/SKILL.md` (marked `legacy: true`). Covers
+Polar as Merchant of Record with references under `references/polar/` (overview, products,
+checkouts, webhooks, benefits, sdk) and `scripts/polar-webhook-verify.js`. Repo slash command
+`integrate:polar` also exists. Use these when implementing; below is setup scope only.
+
+Setup steps (do not build yet):
+1. Polar account + organization. Enable MoR (Polar handles global sales tax/VAT). Verify payout
+   method.
+2. Products / SKUs (one-time, $19.99 each):
+   - Skill pack (advanced Claude Code skills bundle) — one-time.
+   - Workflow flow pack — one-time.
+   - Bundle (both) — one-time, priced below 2×$19.99 to nudge the bundle.
+   Digital product, one-time price (not subscription), USD.
+3. Fulfillment via Polar Benefits (`references/polar/benefits.md`): pick one delivery mechanism:
+   - Polar "file downloads" benefit (Polar hosts the zip) — simplest, no infra.
+   - or GitHub private repo access benefit (gated repo per pack) — good if packs are code that
+     benefits from git updates.
+   Recommend file-download benefit for v1 (least moving parts). Revisit GitHub access if buyers
+   need versioned updates.
+4. Checkout on Astro/Cloudflare Workers:
+   - Simplest: Polar hosted checkout link per product, button links out. No server code.
+   - Embedded: Polar embedded checkout (`references/polar/checkouts.md`) on a new
+     `src/pages/skills.astro` (or `/store`) page, output already `server` (astro.config.mjs:83),
+     so an API route can mint a checkout session server-side with the Polar SDK.
+   - Store `POLAR_ACCESS_TOKEN` as a Cloudflare Worker secret (wrangler secret), never in repo.
+5. Webhook for fulfillment: new route `src/pages/api/polar-webhook.ts` (`prerender = false`,
+   mirror `subscribe.ts` env access via `cloudflare:workers`). Verify signature with
+   `scripts/polar-webhook-verify.js` pattern + `POLAR_WEBHOOK_SECRET`. On `order.paid` /
+   `benefit.granted`, if using Polar benefits the delivery is automatic; the webhook only needs
+   to (optionally) add the buyer to the Substack nurture + log. If self-hosting downloads, mint
+   a signed R2 URL here.
+6. Paid content storage: for file-download benefit, upload packs to Polar. If self-hosting, reuse
+   the existing R2 `MEDIA` bucket (bound as `MEDIA`, astro.config.mjs:164) under a `packs/`
+   prefix, serve via short-lived signed URLs from the webhook/success handler. Keep paid assets
+   out of the public GitHub repo.
+
+Why: lock the shape (SKUs, MoR, fulfillment path, secret names, file locations) before writing
+code, so the build phase is mechanical.
+
+---
+
+## Task 5 — Email split cleanup (Resend transactional, Substack nurture)
+
+Current wiring:
+- `src/pages/download.astro` form posts to `/api/subscribe` (lines 297-301), then on success
+  opens `https://cc4marketing.substack.com/subscribe?email=...` in a background tab (lines
+  313-318). So Substack nurture is already triggered client-side.
+- `src/pages/api/subscribe.ts` sends the Resend welcome+download email (lines 39-70) AND, when
+  `RESEND_AUDIENCE_ID` is set, adds the email to a Resend audience/contacts list (lines 73-83).
+- Substack elsewhere is link-only CTAs (`src/components/blog/PostCta.astro:8`,
+  `src/pages/blog/index.astro:68`, `authors.astro:89`) — no code change needed there.
+
+New rule (owner-confirmed 2026-07-18): Resend = transactional only (auto-send resource/download
+email on every signup). Substack = nurture, and signup must auto-subscribe server-side (not a
+popup). Existing Resend contacts must be exported before the audience code is dropped.
+
+Required flow when a visitor submits the resource/download form:
+1. Resend fires the resource email (download link) immediately. Already works
+   (`subscribe.ts:39-71`), keep.
+2. Same request auto-subscribes the email to Substack server-side (reliable, no popup).
+
+Changes:
+1. Export first (one-time, before code change): pull existing Resend audience contacts (Resend
+   dashboard export or API `GET /audiences/{id}/contacts`), import into Substack so no subscriber
+   is lost. Manual op, do before step 3.
+2. `src/pages/api/subscribe.ts` — add a server-side Substack subscribe call in the same handler,
+   after the Resend email send. Substack's public subscribe endpoint
+   (`https://cc4marketing.substack.com/api/v1/free`, POST `{email, ...}`) is unofficial; wrap in
+   try/catch, do not fail the resource email if Substack errors, log failures. Verify the exact
+   endpoint/payload against a live test before shipping (Substack has no documented API).
+3. `src/pages/api/subscribe.ts` — remove the Resend audience contact push (lines 73-83, and the
+   `RESEND_AUDIENCE_ID` read line 24). Resend now only fires the transactional email.
+4. `src/pages/download.astro` (lines 313-318) — drop the `window.open` Substack popup; the
+   server-side subscribe (step 2) replaces it. Removes the popup-blocked-signup loss.
+5. `src/pages/download.astro:55` success copy "Also subscribed you to course updates via
+   Substack." — still accurate, keep.
+6. Confirm no other page adds to the Resend audience (grep `RESEND_AUDIENCE_ID`).
+
+Why: one signup → resource email (Resend) + nurture list (Substack), both server-side and
+reliable. No popup loss, no orphaned marketing list on Resend.
+
+Risk: Substack has no official API. The `/api/v1/free` endpoint can change or rate-limit. If it
+proves unreliable, fallback is Substack's embeddable form or a redirect-on-success to the hosted
+subscribe page. Test before trusting.
+
+---
+
+## Open risks
+
+- Emdash sitemap disable flag unconfirmed (node_modules read blocked). If it does not exist,
+  Task 1 stays a mitigation, not a fix, until Emdash ships one or Astro's next major forces it.
+- Lesson-count canonical: **19, confirmed.** Reconcile all surfaces to 19 (Task 2).
+- Polar MoR onboarding (identity/tax verification) can take days; start account setup early so it
+  is not the critical-path blocker for the paid launch.
+- Substack has no official API. Server-side subscribe via `/api/v1/free` is unofficial: test live,
+  keep the embeddable-form fallback ready.
+- Export Resend contacts to Substack BEFORE removing the audience code (Task 5 step 1), else lose
+  them.

--- a/plans/20260718-0100-content-growth-strategy/phase-01-library.md
+++ b/plans/20260718-0100-content-growth-strategy/phase-01-library.md
@@ -1,0 +1,151 @@
+# Phase 01: Claude Code Marketing Library
+
+Central growth asset. Curated directory of prompts, slash commands, skills, subagents, MCP servers for marketers using Claude Code. Two jobs: link magnet (free entries drive traffic + email signups) and product shelf (paid packs at $19.99 via Polar). Modeled on sheetsformarketers.com: hub-and-spoke, dense internal links, one master public doc that travels in communities and links back, formulaic cheap-to-produce entry pages.
+
+## Decision: MDX content collection, not D1
+
+Store library entries as MDX in a new `library` content collection (`src/content/library/`), same loader pattern as `modules`. Reasons:
+
+- D1/Emdash blog path has real manual friction (see publish-post SKILL): dry-run python helper, `wrangler d1 execute` exactly once, manual `featured_image` fix, hardcoded `blogPages` array in astro.config for sitemap. Fine for ~10 posts, wrong for 30+ formulaic entries.
+- MDX collection auto-derives sitemap from the filesystem (copy `deriveModuleLessonUrls` in astro.config). New entry = new file, zero extra config, zero D1 round-trip.
+- The artifact (prompt text, command body, skill source) lives inline in the MDX. Git-versioned, greppable, PR-reviewable. No R2 upload dance.
+- Entry pages render server-side like lessons: `getCollection('library')` + `render(entry)`, mirroring `src/pages/modules/[...slug].astro`.
+
+Blog stays on D1 (Emdash owns rich PortableText + OG engine). Library is a separate, simpler surface. Do not force them onto one store.
+
+## 1. Entry schema (`src/content.config.ts`, new collection)
+
+Zod schema, frontmatter per MDX file:
+
+- `name` string. Display title.
+- `slug` string optional. Derived from filename if absent (match modules pattern).
+- `category` enum. One of the category tree below.
+- `type` enum: `prompt | command | skill | subagent | mcp`.
+- `tagline` string, <=90 chars. One-line desc for grid cards + meta description.
+- `description` string. Longer paragraph, the "what + why + when" for the entry body top.
+- `artifact` handled in MDX body, not frontmatter: a fenced code block (copyable) for free entries; for paid, a short preview block + locked marker.
+- `access` enum: `free | paid`.
+- `polarProductId` string optional. Required when `access: paid`.
+- `polarCheckoutUrl` string optional. Direct checkout link (Polar hosted) for the buy button.
+- `price` number optional, default 19.99 when paid.
+- `related` array of slugs. Powers the related-entries block.
+- `author` enum: `tri-vo | alice-marketer`. Reuse existing byline slugs.
+- `tags` array of strings. Freeform (e.g. `seo`, `serp`, `brief`, `b2b-saas`).
+- `updatedAt` date optional. Drives freshness + AEO.
+
+## 2. Category tree
+
+sheetsformarketers ran 17 categories by tool/function. Start narrower (9), by marketing function, so each category page has real density on day one instead of thin stubs. Grow later.
+
+Starting set (slug: label):
+- `seo`: SEO
+- `content`: Content & Copy
+- `paid-ads`: Ads & Paid
+- `analytics`: Analytics & Data
+- `email`: Email & Lifecycle
+- `social`: Social & Community
+- `reporting`: Reporting & Dashboards
+- `competitive`: Competitive Research
+- `project-ops`: Project & Ops
+
+Each maps to course lessons (SEO + content -> Module 2, analytics/reporting -> Module 2 analytics lesson, project-ops -> Module 1 workflows). Add `ads`-adjacent or `crm` categories only once they have 3+ entries.
+
+## 3. URL + hub architecture
+
+Three levels, mirrors the model site:
+
+- `/library/` hub. All categories as cards, brand stats, the free-vs-paid explainer, link to the master public doc, email capture.
+- `/library/[category]/` category page. Grid of entry cards, category intro paragraph (200-300 words, keyword-targeted, hub-page role in the topic cluster), sidebar listing all categories.
+- `/library/[category]/[entry]/` entry page. Formulaic: name, tagline, type + access badges, description, artifact block, install/use steps, Q&A block, related entries, breadcrumbs.
+
+Internal-linking rules (the SEO engine):
+- Sidebar on every category + entry page lists all 9 categories (cross-links the whole hub).
+- Every entry page: breadcrumb `Home > Library > Category > Entry`; a "Related entries" block (3-5 from `related` + same-category fallback).
+- Category page links down to all its entries; entry pages link back up to their category (pillar).
+- Retro-fit: link from relevant blog posts and Module 2 lessons into matching library entries (e.g. the content-strategy lesson links the "SEO content brief" command; the campaign-brief blog post links the brief entries).
+
+Route registration (Astro):
+- Content collection `library` in `src/content.config.ts`.
+- Pages: `src/pages/library/index.astro`, `src/pages/library/[category]/index.astro`, `src/pages/library/[category]/[entry].astro`. Use `getCollection('library')` + `render()`, static-generate with `getStaticPaths` (default prerender, unlike the blog SSR route).
+- Sitemap: add `deriveLibraryUrls()` to astro.config (copy `deriveModuleLessonUrls`, read `src/content/library/`), push hub + category + entry URLs into `customPages`. No hardcoded list, no D1 query. Give entries priority 0.7, category pages 0.8, hub 0.8 in `serialize`.
+
+## 4. Free vs paid split
+
+Free (ungated, real value, the magnet):
+- Single prompts.
+- Single slash commands.
+- Single subagent definitions.
+- Simple project-memory / CLAUDE.md templates.
+
+Paid ($19.99, the shelf):
+- Multi-step skill packs (a skill + its scripts + reference docs bundled).
+- Multi-agent flows (orchestrated subagents + commands that run a full workflow).
+- Anything that replaces a chunk of billable agency work in one shot.
+
+Paid entry page layout:
+- Same header (name, tagline, badges) as free, so it sits in the same grid and gets the same SEO.
+- Real preview: description, what's inside (file list), a screenshot or a trimmed sample of the artifact.
+- Locked artifact block: blurred/omitted body with a "Get this pack" panel = Polar buy button (`polarCheckoutUrl`), price, what you get, refund note.
+- Q&A + related entries still render (AEO + cross-sell).
+
+Bundle: "Marketing Library Pro" = every paid pack, single Polar product, priced below the sum (e.g. 4 packs x $19.99 = ~$80 retail, bundle ~$49). One bundle checkout link surfaced on the hub and on each paid entry page ("or get all packs").
+
+Note: current `faq.astro` says "no paid tier, no upsell." Update that answer when the first pack ships: course stays 100% free, packs are optional add-ons.
+
+## 5. Seed entries (first ~26)
+
+Free lead magnets:
+1. SEO content brief generator (seo, command, free): `/content-brief` builds a full SEO brief from a keyword.
+2. SERP intent classifier (seo, prompt, free): label a keyword list by search intent.
+3. Meta title + description writer (seo, command, free): SERP-length-checked title/description pairs.
+4. Topic cluster mapper (seo, command, free): pillar + supporting posts from a seed keyword. Ties to Module 2.2.
+5. Blog post outline from keyword (content, command, free): H2/H3 outline with intent notes.
+6. Brand voice project-memory template (content, prompt, free): CLAUDE.md block that enforces tone across a project.
+7. Repurpose blog to social (content, command, free): one post -> LinkedIn, X thread, IG carousel copy.
+8. Newsletter draft from a link (email, command, free): summarize + CTA from a URL.
+9. Cold email personalizer (email, prompt, free): per-recipient opening lines from notes.
+10. Ad copy variant generator (paid-ads, command, free): 10 headline/body variants for one offer.
+11. Google Ads negative-keyword finder (paid-ads, prompt, free): mine a search-terms export.
+12. GA4 question answerer (analytics, prompt, free): plain-English questions to GA4 exploration steps.
+13. UTM builder + naming convention (analytics, command, free): consistent tagged links.
+14. Weekly metrics summary prompt (reporting, prompt, free): turn a CSV into a plain-language readout.
+15. Competitor page teardown (competitive, prompt, free): analyze one competitor landing page.
+16. Content calendar scaffold (project-ops, command, free): 90-day rolling calendar. Ties to Module 2.2.
+17. Brand Voice Guardian subagent (content, subagent, free): reviews copy against brand rules.
+18. SEO Specialist subagent (seo, subagent, free): on-page review pass.
+19. Marketing MCP starter list (project-ops, mcp, free): curated MCP servers marketers actually use, with setup notes.
+
+Paid packs:
+20. Competitor teardown skill pack (competitive, skill, paid $19.99): multi-source competitor audit (site + ads + content + social) into one report.
+21. Weekly reporting flow (reporting, skill, paid $19.99): pull metrics, compute deltas, write the exec summary, output a formatted dashboard doc. End to end.
+22. Full content engine flow (content, skill, paid $19.99): research -> topic clusters -> calendar -> briefs -> drafts, chained. Productized version of Module 2.2.
+23. SEO audit skill pack (seo, skill, paid $19.99): tech + on-page + content-gap audit with prioritized fix list. Mirrors the repo's own seo-audit skill, packaged for the student's own site.
+24. Campaign-brief-to-assets flow (project-ops, skill, paid $19.99): brief -> channel plan -> copy -> QA, one command.
+
+Bundle:
+25. Marketing Library Pro bundle (project-ops, skill, paid): all packs, discounted single checkout.
+
+Seed authoring: Tri owns the technical/SEO packs, Alice owns content/email/social entries (matches existing bylines). ~26 entries covers all 9 categories with 2+ each.
+
+## 6. Master public doc
+
+Recommend a public GitHub repo (`cc4-marketing/marketing-library`), not Notion/Sheet. Reasons: audience is Claude Code users (GitHub-native), entries are code, repos travel well in dev/marketing communities, README renders as a directory, stars = social proof, and it lets people PR new entries (community flywheel). Notion/Sheet fits the sheetsformarketers spreadsheet-native audience; ours is code-native.
+
+Structure:
+- `README.md` = the full directory table: category, name, type, free/paid, one-line desc, and a link to the live entry page on cc4.marketing.
+- One folder per category, one `.md` per free entry holding the raw artifact (source of truth the site MDX mirrors, or the site imports).
+- Paid packs: a stub page in the repo (description + "buy on cc4.marketing" link), never the full source.
+
+Flywheel: every repo entry links back to the entry page (traffic + SEO), every entry page links to the repo (stars + shares), the repo README is the artifact that gets pasted into Reddit/X/Slack communities. Add a "Add your own" CONTRIBUTING that routes contributors to the site.
+
+## 7. AEO per entry
+
+Every entry page carries:
+- JSON-LD: `SoftwareSourceCode` (for prompt/command/skill/subagent) or `SoftwareApplication` for MCP entries, plus `BreadcrumbList`. Free entries add the artifact as `text`; include `author`, `keywords` (tags), `isAccessibleForFree`.
+- A `FAQPage`-schema Q&A block, 3-4 pairs per entry ("What does this do?", "How do I install it in Claude Code?", "Is it free?", "What does it pair with?"). Reuses the FAQ schema pattern already shipped on `faq.astro`.
+- llms.txt: new `## Marketing Library` section listing hub + category URLs; llms-full.txt lists each entry URL with its one-line desc (same convention as Published Posts). Update both when entries ship, folded into the entry-publish flow.
+
+## Open questions
+
+- Polar not yet integrated (no code refs found). Blocks paid entries. Sequence: ship free library first (magnet + SEO), wire Polar via the `integrate:polar` command + payment-integration skill in a later phase, then flip on paid packs.
+- Entry-publish automation: worth a small `/publish-library-entry` skill (scaffold MDX + frontmatter + llms.txt append), but only after the manual pattern proves out on the first ~10.

--- a/plans/20260718-0100-content-growth-strategy/phase-02-content-engine.md
+++ b/plans/20260718-0100-content-growth-strategy/phase-02-content-engine.md
@@ -1,0 +1,59 @@
+# Phase 02: Content engine + distribution flywheel
+
+Spoke tutorials that feed the Library (Phase 1) and the email list. Formulaic, cheap, AEO-weighted. Modeled on sheetsformarketers' "how to X in Google Sheets" long tail, adapted: "how to [marketing task] with Claude Code (+ copy-paste [prompt/command])".
+
+## Why this shape
+
+- Each tutorial targets one task a marketer searches for, ends with a real artifact, and links to the matching Library entry. Tutorial ranks/gets cited, Library entry converts (email + later paid pack).
+- "claude code" search volume is small and moving, so weight AEO (llms.txt, FAQ schema, clean structure) over pure keyword volume. Goal: get cited by AI answer engines, not just rank.
+
+## Tutorial template (repeatable, ~700-900 words)
+
+Every post follows the same skeleton so it is fast to produce and consistent to crawl:
+
+1. Title: `How to [task] with Claude Code (+ [copy-paste prompt|slash command])`. Year in title where it helps freshness.
+2. One-paragraph problem framing (who has this task, why it is slow by hand).
+3. What you need (Claude Code installed, link Module 0 install lesson).
+4. The steps: 3-6 numbered steps, each with the exact thing to type. Real commands, no hand-waving.
+5. The artifact: the full prompt or slash command in a fenced block, copyable. Same artifact as the Library entry (single source: link to the entry, do not fork the text).
+6. Example output (trimmed, real).
+7. "Take it further" -> link the Library entry + 1 related tutorial + 1 course lesson.
+8. Q&A block (3-4 pairs) -> FAQPage schema (reuse faq.astro pattern).
+9. CTA: subscribe (Substack) + browse the Library.
+
+Frontmatter (publish-post schema): title <=60, excerpt <=160, author (tri-vo or alice-marketer), keywords. Cover: let the OG engine auto-generate.
+
+## Cadence + ownership
+
+- 2 posts/week, AI-assisted. Tri owns SEO/technical/analytics topics, Alice owns content/email/social. Match the byline to the Library category.
+- Batch: draft 4-6 at once from the Library entries that already exist (each free entry = one tutorial). The first 13 tutorials write themselves from the 13 seed entries.
+- Pipeline: draft md -> /publish-post (D1 insert + sitemap + auto llms sync from phase 0) -> /ship. No new tooling needed.
+
+## First batch (from existing Library entries)
+
+Each maps 1:1 to a shipped free entry (flywheel):
+1. How to Write an SEO Content Brief with Claude Code (+ slash command) -> library/seo/content-brief-generator. [draft written: first-tutorial-draft.md]
+2. How to Classify Keywords by Search Intent with Claude Code -> library/seo/serp-intent-classifier.
+3. How to Turn One Blog Post into a Week of Social Posts -> library/content/repurpose-blog-to-social.
+4. How to Draft a LinkedIn Post from Rough Notes with Claude Code -> library/social/linkedin-post-from-notes.
+5. How to Answer GA4 Questions in Plain English with Claude Code -> library/analytics/ga4-question-answerer.
+6. How to Write Ad Copy Variants Fast with Claude Code -> library/paid-ads/ad-copy-variants.
+
+## Distribution flywheel (non-code, needs owner)
+
+- Launch the Library as an event, not a slow SEO bet: Product Hunt, Show HN, r/ClaudeAI, r/marketing, LinkedIn, X. The master GitHub repo (cc4-marketing/marketing-library) is the shareable artifact pasted into communities.
+- Expert roundup post: "How N marketers use Claude Code" (interview the community, each interviewee shares -> backlinks + relationships).
+- Substack nurture, weekly: 1 new Library entry + 1 tutorial + 1 soft paid-pack mention (once packs ship).
+- Retrofit internal links (code task, small PR): from existing blog posts and Module 2 lessons into matching Library entries (e.g. content-strategy lesson -> content-brief-generator entry; campaign-brief post -> brief entries).
+
+## AEO for tutorials
+
+- FAQPage schema per post (already the site pattern).
+- Add each published tutorial to llms.txt Published Posts (auto via phase-0 publish_post.py change) and cross-reference the Library entry.
+- Add a `## Marketing Library` section to llms.txt/llms-full.txt (deferred from Phase 1) so engines see the whole directory.
+
+## Follow-ups / open
+
+- Publishing is a production deploy (D1 + wrangler + ship). Needs owner go-ahead per post or per batch; do not auto-deploy.
+- Master GitHub repo not created yet (hub forward-links to it).
+- Retrofit-links PR not started.

--- a/plans/20260718-0100-content-growth-strategy/plan.md
+++ b/plans/20260718-0100-content-growth-strategy/plan.md
@@ -1,0 +1,67 @@
+# Chiến lược nội dung & growth cc4.marketing (mô hình sheetsformarketers.com)
+
+Ngày: 2026-07-18. Nguồn: nghiên cứu sâu sheetsformarketers.com + rà toàn bộ repo cc4-site.
+
+## Quyết định đã chốt (2026-07-18)
+
+- Thị trường chính: EN global. Kênh phân phối: Product Hunt, r/ClaudeAI, Hacker News, LinkedIn, X.
+- Course free = top of funnel, build audience + email list.
+- Monetization: bán advanced skills và flows (skill packs, workflow templates trả phí).
+- Email: Substack = newsletter/nurture, Resend = transactional (welcome, download, receipt).
+- Viết đều đặn: AI-assisted, dùng cả 2 persona Tri (Course Creator) + Alice (AI Marketing Strategist).
+- Giá: skill pack/flow $19.99, bán lẻ và bundle đều được.
+- Thanh toán: Polar (MoR lo tax EU/US, đã có skill payment-integration).
+
+## Bài học lõi từ sheetsformarketers.com (SFM)
+
+- Directory tuyển chọn trước, nội dung gốc sau. Founder không tự làm template nào lúc launch, chỉ curate 100+ sheet của người khác. Mỗi creator được feature trở thành người chia sẻ/backlink.
+- Kiến trúc hub-and-spoke 3 tầng: homepage -> 5 hub -> 17 category -> bài lẻ. Internal link dày ở sidebar/footer.
+- Tutorial công thức hóa: "How to X in Google Sheets in 2026 (+ Examples)", 600-700 từ, kèm artifact copy được. Rẻ, lặp lại được, ~400 bài.
+- 1 master Google Sheet public chứa cả directory: tự lan truyền, tự rank, tự kéo link.
+- Expert roundup ("50+ tips theo 85 marketers") để sản xuất backlink + quan hệ.
+- Resource không gate, email là lời mời phụ. Launch bằng cộng đồng (Product Hunt) chứ không chờ SEO.
+- Cảnh báo: SFM kiếm tiền kém, đứng im từ 2024. Đây là playbook kéo audience, không phải business model.
+
+## Hiện trạng cc4.marketing (điểm tựa + gap)
+
+- Điểm tựa: nền SEO/AEO tốt (llms.txt, FAQPage schema, robots đã sửa, sitemap chuẩn), pipeline publish-post tự động hóa một phần, changelog máy-đọc-được, brand system rõ, course 18 bài là lead magnet sẵn.
+- Gap: chưa có editorial strategy; blog 9 bài đăng thất thường (6 bài T4, trống 2 tháng); chưa có keyword map; 2 newsletter (Substack + Resend) chưa phân vai; funnel không có KPI; EN/VN chưa chốt; sitemap Emdash collision là rủi ro treo; lesson count lệch giữa các surface.
+
+## Outline chiến lược cập nhật
+
+### Giai đoạn 0: chốt nền (1 tuần)
+- Dọn nợ: thống nhất lesson count, xử lý sitemap Emdash, tự động sync llms.txt trong skill publish-post.
+- Setup bán hàng: tích hợp Polar (skill payment-integration). SKU đầu tiên: 1 advanced skill pack + 1 flow, mỗi cái $19.99, thêm bundle (2+ pack) giảm giá nhẹ.
+- Nối Substack vào mọi trang (thay form Resend generic): Resend chỉ còn transactional.
+
+### Giai đoạn 1: Directory play, tài sản trung tâm (2-4 tuần)
+- Xây "Claude Code Marketing Library": directory curate prompts, slash commands, skills, MCP servers, subagents cho marketer. Category theo chức năng: SEO, content, ads, analytics, email, social, reporting.
+- Mỗi entry: tên, mô tả 1-2 câu, artifact copy/tải được (file .md command thật). Curate của cộng đồng + của mình (khác SFM: nguồn cung ít nên tự author nhiều hơn, đổi lại defensible).
+- 1 master doc public (GitHub repo hoặc Sheet) chứa cả library, kèm link về site.
+- Free/paid split ngay trong library: entry free (prompts, commands đơn) đầy đủ và không gate; entry advanced (skill packs, multi-step flows) hiện trong cùng category nhưng dẫn sang trang bán. Directory vừa là link magnet vừa là kệ hàng.
+- Launch như sự kiện: Product Hunt, r/ClaudeAI, Hacker News (Show HN), LinkedIn, X.
+
+### Giai đoạn 2: Spoke tutorials công thức hóa (liên tục)
+- Pattern: "How to [task] with Claude Code (+ copy-paste prompt)" 600-900 từ, cấu trúc y hệt nhau, năm trong title, 4 internal link (hub + lesson liên quan + 2 bài anh em).
+- Ưu tiên AEO/LLM discoverability hơn volume SEO thuần: search volume "claude code" còn nhỏ và biến động, nhưng AI engines đang trích dẫn; cc4 đã có lợi thế llms.txt/FAQ. Mỗi bài thêm Q&A block + schema.
+- Cadence tối thiểu: 2 bài/tuần từ tutorial template, xen 1 bài thought-leadership/tháng (giữ giọng hiện có).
+
+### Giai đoạn 3: Flywheel phân phối + backlink
+- Expert roundup: "N marketers dùng Claude Code thế nào" (phỏng vấn cộng đồng, mỗi người được feature sẽ share).
+- Form submit tool/prompt vào library: giữ nguồn cung + quan hệ.
+- Email: Resend giữ welcome/download (transactional); nurture đi qua Substack, mỗi tuần 1 số: 1 entry library nổi bật + 1 tutorial + 1 nhắc paid pack. Broadcast khi có lesson/pack mới.
+
+### Giai đoạn 4: Funnel + đo lường
+- Funnel: tutorial/library (free) -> subscribe Substack + download course (Resend) -> course modules -> paid skill packs/flows. Mỗi lesson advanced và mỗi entry free có CTA sang pack liên quan.
+- KPI: Substack subscribers, course starts (/start-0-0), GitHub stars/clones, số entry library, bài được AI engines trích dẫn, doanh thu pack + conversion rate list -> paid.
+- Case study kéo trust: Threadmark, sigil, castmd làm proof cho paid flows.
+- Baseline: export GA4 + Search Console ngay để có số trước khi chạy.
+
+## Phase file chi tiết
+- `phase-00-debt-cleanup.md`: sitemap Emdash collision, thống nhất lesson count, auto-sync llms.txt, prep Polar, tách email Resend/Substack.
+- `phase-01-library.md`: entry schema, 9 category, URL/hub, free/paid split, ~26 seed entry, master GitHub repo, AEO per entry.
+
+## Quyết định đã chốt thêm (2026-07-18)
+- Canonical lesson count: 19 (github-pr-guide tính là lesson). Reconcile mọi surface về 19.
+- Email flow: 1 signup -> Resend gửi resource/download (transactional) + auto-subscribe Substack server-side (không popup). Export contact Resend cũ sang Substack trước khi bỏ audience code.
+- Cập nhật FAQ ("no paid tier") khi pack đầu ship.

--- a/plans/20260718-0100-content-growth-strategy/todo.md
+++ b/plans/20260718-0100-content-growth-strategy/todo.md
@@ -15,19 +15,24 @@ Trạng thái: `[x]` xong, `[~]` chặn/chờ, `[ ]` chưa làm.
   - [ ] `subscribe.ts`: bỏ push Resend audience (dòng 73-83 + read `RESEND_AUDIENCE_ID`)
   - [ ] `download.astro`: bỏ popup `window.open` Substack (dòng 313-318)
 
-## Phase 1 — Library (chưa bắt đầu)
-- [ ] Tạo MDX content collection `library` (copy pattern `modules`)
-- [ ] Routes `/library/`, `/library/[category]/`, `/library/[category]/[entry]/` + `deriveLibraryUrls()` vào astro.config
-- [ ] 9 category theo chức năng marketing
-- [ ] Entry schema (type, access free|paid, polarProductId, author, related, tags)
-- [ ] Viết ~26 seed entry (19 free + 5 paid pack + 1 bundle)
-- [ ] Free/paid split UI: paid entry = preview + locked artifact + nút Polar
-- [ ] Master public doc (GitHub repo) + link-back flywheel
-- [ ] AEO per entry: SoftwareSourceCode + BreadcrumbList JSON-LD + Q&A block + mục llms.txt
+## Phase 1 — Library (PR #27, chờ merge)
+- [x] MDX content collection `library` + Zod schema (paid field sẵn)
+- [x] Routes hub/category/entry + `deriveLibraryUrls()` sitemap
+- [x] 9 category theo chức năng marketing
+- [x] 13 seed entry free phủ 9 category (artifact thật)
+- [x] AEO per entry: SoftwareSourceCode + FAQPage + BreadcrumbList JSON-LD
+- [~] Paid entry (5 pack + bundle) + free/paid split UI + nút Polar — chặn Polar (Task 4)
+- [ ] Mục `## Marketing Library` trong llms.txt/llms-full.txt (deferred)
+- [ ] Nav link `/library/` vào siteData.ts (thuộc PR #26, thêm khi merge)
+- [ ] Master GitHub repo `cc4-marketing/marketing-library` (hub đã forward-link)
 - [ ] Cập nhật `faq.astro` ("no paid tier") khi pack đầu ship
 
-## Phase 2+ — nội dung & phân phối (chưa bắt đầu)
-- [ ] Template tutorial "How to [task] with Claude Code (+ prompt)", 2 bài/tuần, AI-assisted (Tri + Alice)
+## Phase 2 — nội dung & phân phối (đã bắt đầu)
+- [x] Template tutorial + cadence + ownership — `phase-02-content-engine.md`
+- [x] Draft bài đầu "SEO Content Brief with Claude Code" — `first-tutorial-draft.md`
+- [ ] Publish bài đầu qua /publish-post + /ship (chờ bạn cho phép deploy production)
+- [ ] Draft 5 bài batch đầu (map 1:1 với library entry)
+- [ ] Retrofit internal link: blog + Module 2 lesson -> library entry (PR nhỏ)
 - [ ] Launch Library như sự kiện: Product Hunt, Show HN, r/ClaudeAI, LinkedIn, X
 - [ ] Expert roundup "N marketers dùng Claude Code thế nào" (backlink)
 - [ ] Substack nurture hàng tuần: 1 entry + 1 tutorial + 1 nhắc paid

--- a/plans/20260718-0100-content-growth-strategy/todo.md
+++ b/plans/20260718-0100-content-growth-strategy/todo.md
@@ -1,0 +1,39 @@
+# TODO — content & growth (cập nhật 2026-07-18)
+
+Trạng thái: `[x]` xong, `[~]` chặn/chờ, `[ ]` chưa làm.
+
+## Phase 0 — dọn nợ
+- [x] Task 2: reconcile lesson count về 19 (7 file) — PR #26
+- [x] Task 3: auto-sync llms.txt/llms-full.txt trong publish_post.py — PR #26
+- [x] chore: gitignore `__pycache__/` — PR #26
+- [~] Task 1: sitemap Emdash collision. Chặn: node_modules bị hook chặn, chưa verify flag disable-sitemap của emdash 0.1.0. Redirect vẫn chạy, mới là warning. Việc cần: xác nhận flag (đọc docs emdash hoặc tạm tắt hook) rồi tắt sitemap của emdash trong astro.config.mjs.
+- [~] Task 4: prep Polar. Chặn: chờ tạo account + MoR onboarding (vài ngày). Việc cần: tạo org, bật MoR, verify thuế/payout.
+- [~] Task 5: tách email. Chặn: chờ export contact Resend + xác nhận endpoint Substack. Việc cần:
+  - [ ] export contact Resend hiện có, import sang Substack (thủ công, làm trước)
+  - [ ] xác nhận endpoint `/api/v1/free` của Substack bằng test email thật
+  - [ ] `subscribe.ts`: thêm auto-subscribe Substack server-side sau khi gửi Resend
+  - [ ] `subscribe.ts`: bỏ push Resend audience (dòng 73-83 + read `RESEND_AUDIENCE_ID`)
+  - [ ] `download.astro`: bỏ popup `window.open` Substack (dòng 313-318)
+
+## Phase 1 — Library (chưa bắt đầu)
+- [ ] Tạo MDX content collection `library` (copy pattern `modules`)
+- [ ] Routes `/library/`, `/library/[category]/`, `/library/[category]/[entry]/` + `deriveLibraryUrls()` vào astro.config
+- [ ] 9 category theo chức năng marketing
+- [ ] Entry schema (type, access free|paid, polarProductId, author, related, tags)
+- [ ] Viết ~26 seed entry (19 free + 5 paid pack + 1 bundle)
+- [ ] Free/paid split UI: paid entry = preview + locked artifact + nút Polar
+- [ ] Master public doc (GitHub repo) + link-back flywheel
+- [ ] AEO per entry: SoftwareSourceCode + BreadcrumbList JSON-LD + Q&A block + mục llms.txt
+- [ ] Cập nhật `faq.astro` ("no paid tier") khi pack đầu ship
+
+## Phase 2+ — nội dung & phân phối (chưa bắt đầu)
+- [ ] Template tutorial "How to [task] with Claude Code (+ prompt)", 2 bài/tuần, AI-assisted (Tri + Alice)
+- [ ] Launch Library như sự kiện: Product Hunt, Show HN, r/ClaudeAI, LinkedIn, X
+- [ ] Expert roundup "N marketers dùng Claude Code thế nào" (backlink)
+- [ ] Substack nurture hàng tuần: 1 entry + 1 tutorial + 1 nhắc paid
+- [ ] Baseline: export GA4 + Search Console để có số trước khi chạy
+
+## Việc chỉ bạn làm được (không code)
+- [ ] Polar account + MoR onboarding (khởi động sớm, kẻo chặn launch paid)
+- [ ] Export contact Resend
+- [ ] Quyết: có commit thư mục `plans/` vào repo không

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,6 +1,6 @@
 # CC4.Marketing — Full Course Reference
 
-> This is the extended version of llms.txt with complete lesson details. Course summary: 4 modules, 18 lessons. For a concise overview, see: https://cc4.marketing/llms.txt
+> This is the extended version of llms.txt with complete lesson details. Course summary: 4 modules, 19 lessons. For a concise overview, see: https://cc4.marketing/llms.txt
 
 ## Blog
 The CC4.Marketing blog publishes practical guides on AI-powered marketing with Claude Code.
@@ -124,7 +124,7 @@ Objectives:
 
 ---
 
-## Module 2: Advanced Applications (6 lessons, ~4-5 hours)
+## Module 2: Advanced Applications (7 lessons, ~4-5 hours)
 
 ### Lesson 2.1 — Write a Campaign Brief (45 min)
 Path: /modules/2/campaign-brief/
@@ -179,6 +179,16 @@ Objectives:
 - Optimize content for search engines
 - Build pillar pages and topic clusters
 - Understand technical SEO fundamentals
+
+### Lesson 2.7 — Service Package from a Real Engagement (60 min)
+Path: /modules/2/service-package-from-engagement/
+Description: Turn a successful client engagement into a sellable service package: mine the project docs with an agent, write a service blueprint, and derive a case study, landing page, deck, and one-pager that all tell the same story.
+Objectives:
+- Mine a real project corpus for operations, metrics, feedback, and proof points
+- Make the five decisions that shape a service package before writing anything
+- Write a service blueprint an operations team can actually run
+- Derive marketing assets from one source of truth so numbers never drift
+- Apply anonymization and verification gates before anything ships
 
 ---
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,6 +1,6 @@
 # CC4.Marketing — Claude Code for Marketers
 
-> A free, interactive course teaching marketers how to use Claude Code to work 10x faster. 4 modules, 18 lessons, taught entirely inside Claude Code itself.
+> A free, interactive course teaching marketers how to use Claude Code to work 10x faster. 4 modules, 19 lessons, taught entirely inside Claude Code itself.
 
 ## About
 CC4.Marketing is an open-source course that teaches AI-powered marketing workflows. Students install Claude Code, clone a starter project, then type /start-0-0 to begin interactive lessons. The practice project simulates working as a Marketing Strategist at "Markit" agency, running campaigns for a B2B SaaS client called "Planerio."
@@ -34,7 +34,7 @@ The blog publishes practical guides, tutorials, and insights on AI-powered marke
 ## Course Modules
 - Module 0: Getting Started (4 lessons, 30 min) — Installation, setup, first task
 - Module 1: Core Concepts (7 lessons, 3-4 hours) — Agents, sub-agents, project memory, marketing workflows
-- Module 2: Advanced Applications (6 lessons, 4-5 hours) — Campaign briefs, content strategy, copy, analytics, SEO
+- Module 2: Advanced Applications (7 lessons, 4-5 hours) — Campaign briefs, content strategy, copy, analytics, competitive analysis, SEO, service packaging
 - Module 3: Capstone (1 lesson, 75 min) — Ship a Real Follow-Up with sigil, an open-source CLI inside Claude Code (https://github.com/blacklogos/sigil). Real send pipeline on Cloudflare Workers, custom `/email-rewrite` slash command, per-recipient handcrafted sentences.
 
 ## Changelog API

--- a/src/config/siteData.ts
+++ b/src/config/siteData.ts
@@ -34,7 +34,7 @@ export const siteData = {
         title: 'Getting Started',
         description: 'Install Claude Code and get your first taste of AI-powered marketing.',
         lessonCount: '4 Lessons • 30 minutes',
-        lessons: ['Introduction', 'Installation', 'First Task'],
+        lessons: ['Introduction', 'Installation', 'First Task', 'GitHub & PRs'],
         href: '/modules/0/introduction/'
       },
       {

--- a/src/lib/og/build.ts
+++ b/src/lib/og/build.ts
@@ -153,7 +153,7 @@ const STATIC_PAGES: Record<
   },
   modules: {
     title: 'All Modules',
-    subtitle: 'The full CC4.Marketing curriculum — four modules, 18 lessons, install to shipped campaign.',
+    subtitle: 'The full CC4.Marketing curriculum: four modules, 19 lessons, install to shipped campaign.',
     accent: 'rust',
     badge: 'CURRICULUM',
   },

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -9,7 +9,7 @@ import Footer from '../components/Footer.astro';
 const faqs = [
   {
     q: 'Is the Claude Code for Marketers course free?',
-    a: 'Yes. The course is 100% free and open source (MIT license). All 4 modules and 18 lessons are available to everyone. There is no paid tier, no certificate fee, and no upsell.',
+    a: 'Yes. The course is 100% free and open source (MIT license). All 4 modules and 19 lessons are available to everyone. There is no paid tier, no certificate fee, and no upsell.',
   },
   {
     q: 'Do I need to pay for anything at all?',
@@ -17,7 +17,7 @@ const faqs = [
   },
   {
     q: 'How many lessons are there and how long does it take?',
-    a: 'Four modules with 18 lessons: Getting Started (3 lessons), Core Concepts (7), Advanced Applications (7), and a hands-on Capstone. Most students finish in about 2 weeks working through a few lessons per session.',
+    a: 'Four modules with 19 lessons: Getting Started (4 lessons), Core Concepts (7), Advanced Applications (7), and a hands-on Capstone (1). Most students finish in about 2 weeks working through a few lessons per session.',
   },
   {
     q: 'Do I need to know how to code?',
@@ -50,7 +50,7 @@ const faqSchema = {
 
 <BaseLayout
   title="FAQ & Pricing | Claude Code for Marketers"
-  description="Claude Code for Marketers is 100% free: 4 modules, 18 lessons, open source. FAQ on pricing, prerequisites, syllabus, and how to start."
+  description="Claude Code for Marketers is 100% free: 4 modules, 19 lessons, open source. FAQ on pricing, prerequisites, syllabus, and how to start."
   keywords={['Claude Code for Marketers pricing', 'cc4.marketing free', 'AI marketing course FAQ', 'Claude Code course cost']}
   showCourseSchema={false}
   showBreadcrumb={false}
@@ -61,7 +61,7 @@ const faqSchema = {
     <div class="faq-container">
       <h1>Frequently Asked Questions</h1>
       <p class="faq-intro">
-        Short version: the course is free, open source, 18 lessons, no coding required.
+        Short version: the course is free, open source, 19 lessons, no coding required.
         Details below.
       </p>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -149,7 +149,7 @@ import WhatsNew from '../components/WhatsNew.astro';
       <div class="section-header">
         <div class="section-label">Four Modules</div>
         <h2 class="section-title">Your Learning Path</h2>
-        <p class="section-description">Master AI-powered marketing in 2 weeks. Four modules. 18 lessons. Real transformations.</p>
+        <p class="section-description">Master AI-powered marketing in 2 weeks. Four modules. 19 lessons. Real transformations.</p>
       </div>
 
       <div class="modules-grid">


### PR DESCRIPTION
## What

Phase 0 debt cleanup (the code-only tasks that needed no external accounts). Part of the content/growth strategy work in `plans/20260718-0100-content-growth-strategy/`.

### fix(content): reconcile lesson count to 19
Canonical count set to **4 modules, 19 lessons** (github-pr-guide counts as a lesson, matching disk 1:1). Fixed stale 17/18 figures plus the missing Module 3 and Module 2.7 references across:
- README (intro line, structure comment, module table)
- siteData (Module 0 title list)
- llms.txt / llms-full.txt (counts, Module 2 6 to 7, added Lesson 2.7 entry)
- faq.astro (4 spots)
- homepage section + OG subtitle

### feat(publish-post): auto-sync llms files on publish
`publish_post.py` now appends the new post to llms.txt and llms-full.txt after the sitemap step on `--execute`, reusing the frontmatter excerpt. Idempotent. Removes the manual Step 5b edit that silently broke AI discoverability when skipped.

### chore: ignore Python bytecode cache

## Verify
- `grep -rn "18 lesson|17 lesson" src/ public/ README.md` clean
- `npm run build` completes (only the pre-existing sitemap-collision warning and chunk-size warning remain)
- `npm test` 37 passed
- auto-sync tested on temp copies: appends both files, idempotent on re-run

## Not in this PR (blocked on external setup)
- Task 1 sitemap collision: emdash 0.1.0 disable-sitemap flag unverifiable (node_modules read blocked); redirect still works, warning only
- Task 4 Polar integration: needs Polar account + MoR onboarding
- Task 5 email split: needs Resend contact export + Substack endpoint confirmation
