### PR TITLE
Phase 1: free Claude Code Marketing Library

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -59,8 +59,31 @@ function deriveAuthorUrls() {
     .sort();
 }
 
+// Auto-derive Marketing Library URLs from src/content/library/{category}/*.mdx.
+// Mirrors deriveModuleLessonUrls(): reading at config-load means new categories
+// and entries appear in the sitemap with zero extra config. URLs are driven off
+// the folder (category) + filename (entry slug), matching the route pattern
+// /library/{category}/{fileslug}/.
+function deriveLibraryUrls() {
+  const ROOT = './src/content/library';
+  const urls = new Set([`${SITE_URL}/library/`]);
+  if (!fs.existsSync(ROOT)) return [...urls];
+  for (const dir of fs.readdirSync(ROOT, { withFileTypes: true })) {
+    if (!dir.isDirectory()) continue;
+    const category = dir.name;
+    urls.add(`${SITE_URL}/library/${category}/`);
+    for (const file of fs.readdirSync(`${ROOT}/${category}`)) {
+      if (!file.endsWith('.mdx')) continue;
+      const fileslug = file.replace(/\.mdx$/, '');
+      urls.add(`${SITE_URL}/library/${category}/${fileslug}/`);
+    }
+  }
+  return [...urls].sort();
+}
+
 const modulePages = deriveModuleLessonUrls();
 const authorPages = deriveAuthorUrls();
+const libraryPages = deriveLibraryUrls();
 const modulesHub = `${SITE_URL}/modules/`;
 
 // Blog post URLs are still hardcoded — Emdash D1 is not queryable from this
@@ -86,7 +109,7 @@ export default defineConfig({
     react(),
     mdx(),
     sitemap({
-      customPages: [...modulePages, modulesHub, ...authorPages, ...blogPages],
+      customPages: [...modulePages, modulesHub, ...authorPages, ...blogPages, ...libraryPages],
       // Exclude dev-only routes from the sitemap. These are gated behind
       // import.meta.env.DEV (404 in production) and Disallowed in robots.txt;
       // including them in the sitemap sends a contradictory signal to crawlers.
@@ -149,6 +172,14 @@ export default defineConfig({
         else if (url.includes('/changelog')) {
           item.priority = 0.8;
           item.changefreq = 'weekly';
+        }
+        // Marketing Library: hub + category pages 0.8, entry pages 0.7.
+        // Depth is the number of path segments after /library/.
+        else if (url.includes('/library/')) {
+          const rest = url.split('/library/')[1].replace(/\/$/, '');
+          const depth = rest === '' ? 0 : rest.split('/').length;
+          item.priority = depth >= 2 ? 0.7 : 0.8;
+          item.changefreq = 'monthly';
         }
         // Default
         else {

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -199,6 +199,33 @@ Companion CLI: https://github.com/blacklogos/sigil (MIT, open-source)
 
 ---
 
+## Marketing Library
+The Marketing Library is a curated directory of free Claude Code prompts, slash commands, subagents, and MCP lists for marketers. Every entry is a real, copyable artifact organized into 9 categories. Hub: https://cc4.marketing/library/
+
+Entries:
+- GA4 Question Answerer (https://cc4.marketing/library/analytics/ga4-question-answerer/): Turn a plain English analytics question into GA4 exploration steps.
+- UTM Builder (https://cc4.marketing/library/analytics/utm-builder/): Build consistent UTM tagged URLs from your naming rules and flag drift.
+- Competitor Page Teardown (https://cc4.marketing/library/competitive/competitor-page-teardown/): Analyze one competitor landing page for offer, proof, CTA, and gaps.
+- Content Gap Finder (https://cc4.marketing/library/competitive/content-gap-finder/): Compare a competitor's topic coverage to yours and rank the gaps to target.
+- Blog Post Outline Builder (https://cc4.marketing/library/content/blog-post-outline/): Turn a keyword into an H2 and H3 outline with intent notes.
+- Brand Voice Memory Block (https://cc4.marketing/library/content/brand-voice-memory/): A CLAUDE.md block that keeps every draft on brand across a project.
+- Blog to Social Repurposer (https://cc4.marketing/library/content/repurpose-blog-to-social/): Turn one blog post into a LinkedIn post, an X thread, and a carousel.
+- Newsletter Section from a Link (https://cc4.marketing/library/email/newsletter-from-link/): Summarize a URL into a newsletter section with subject line and CTA.
+- Welcome Sequence Outline (https://cc4.marketing/library/email/welcome-sequence-outline/): Outline a 4 to 5 email onboarding drip with goal, subject, and CTA per email.
+- Ad Copy Variant Generator (https://cc4.marketing/library/paid-ads/ad-copy-variants/): Generate 10 headline and primary text variants, each with an angle.
+- Negative Keyword Finder (https://cc4.marketing/library/paid-ads/negative-keyword-finder/): Mine a Google Ads search terms export for negative keywords, grouped by reason.
+- Content Calendar Scaffold (https://cc4.marketing/library/project-ops/content-calendar-scaffold/): Build a 90 day rolling content calendar from a short description.
+- Marketing MCP Starter (https://cc4.marketing/library/project-ops/marketing-mcp-starter/): A starter set of MCP servers marketers actually use with Claude Code.
+- Weekly Metrics Summary (https://cc4.marketing/library/reporting/weekly-metrics-summary/): Turn a metrics CSV into a plain language weekly readout with deltas.
+- Monthly Report Outline (https://cc4.marketing/library/reporting/monthly-report-outline/): Produce an executive monthly marketing report outline leaders will read.
+- Content Brief Generator (https://cc4.marketing/library/seo/content-brief-generator/): Turn one keyword into a full SEO content brief a writer can follow.
+- Meta Title and Description Writer (https://cc4.marketing/library/seo/meta-title-description-writer/): Write SERP length checked title and description pairs that fit Google.
+- SERP Intent Classifier (https://cc4.marketing/library/seo/serp-intent-classifier/): Label a keyword list by search intent, with a reason for each call.
+- LinkedIn Post from Notes (https://cc4.marketing/library/social/linkedin-post-from-notes/): Draft a LinkedIn post from rough bullet notes, with a hook and CTA.
+- Weekly Social Plan (https://cc4.marketing/library/social/weekly-social-plan/): Turn your content pillars into a 7 day social plan with hooks and CTAs.
+
+---
+
 ## Changelog API
 - JSON: https://cc4-changelog.mtri-vo.workers.dev/api/changelog
 - RSS: https://cc4-changelog.mtri-vo.workers.dev/rss.xml

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -37,6 +37,20 @@ The blog publishes practical guides, tutorials, and insights on AI-powered marke
 - Module 2: Advanced Applications (6 lessons, 4-5 hours) — Campaign briefs, content strategy, copy, analytics, SEO
 - Module 3: Capstone (1 lesson, 75 min) — Ship a Real Follow-Up with sigil, an open-source CLI inside Claude Code (https://github.com/blacklogos/sigil). Real send pipeline on Cloudflare Workers, custom `/email-rewrite` slash command, per-recipient handcrafted sentences.
 
+## Marketing Library
+The Marketing Library is a curated directory of free Claude Code prompts, slash commands, subagents, and MCP lists for marketers. Every entry is a real, copyable artifact organized into 9 categories.
+
+- Library hub: https://cc4.marketing/library/
+- SEO (https://cc4.marketing/library/seo/): keyword research, content briefs, and SERP intent prompts
+- Content & Copy (https://cc4.marketing/library/content/): outlines, brand voice, and repurposing workflows
+- Ads & Paid (https://cc4.marketing/library/paid-ads/): headline and primary text variant helpers
+- Analytics & Data (https://cc4.marketing/library/analytics/): plain English questions into GA4 steps
+- Email & Lifecycle (https://cc4.marketing/library/email/): newsletter, subject line, and lifecycle copy
+- Social & Community (https://cc4.marketing/library/social/): posts, threads, and captions from notes
+- Reporting & Dashboards (https://cc4.marketing/library/reporting/): metrics into weekly readouts
+- Competitive Research (https://cc4.marketing/library/competitive/): teardowns of rival pages and offers
+- Project & Ops (https://cc4.marketing/library/project-ops/): calendars, briefs, and repeatable systems
+
 ## Changelog API
 The changelog tracks all course and site updates. Each entry includes a `machine_summary` field optimized for agent consumption.
 

--- a/src/components/library/category-sidebar.astro
+++ b/src/components/library/category-sidebar.astro
@@ -1,0 +1,99 @@
+---
+import { LIBRARY_CATEGORIES } from '../../data/library-categories';
+
+interface Props {
+  /** Slug of the active category, if any, to highlight in the list. */
+  active?: string;
+  counts?: Record<string, number>;
+}
+
+const { active, counts } = Astro.props;
+---
+
+<nav class="lib-sidebar" aria-label="Library categories">
+  <a href="/library/" class="lib-sidebar-home">All categories</a>
+  <ul class="lib-sidebar-list">
+    {LIBRARY_CATEGORIES.map((cat) => (
+      <li>
+        <a
+          href={`/library/${cat.slug}/`}
+          class={`lib-sidebar-link ${cat.slug === active ? 'is-active' : ''}`}
+          aria-current={cat.slug === active ? 'page' : undefined}
+        >
+          <span>{cat.label}</span>
+          {counts && <span class="lib-sidebar-count">{counts[cat.slug] ?? 0}</span>}
+        </a>
+      </li>
+    ))}
+  </ul>
+</nav>
+
+<style>
+  .lib-sidebar {
+    border: 2px solid var(--border-color);
+    background: var(--bg-secondary);
+    padding: 20px;
+    box-shadow: var(--shadow-sm);
+    position: sticky;
+    top: 96px;
+  }
+
+  .lib-sidebar-home {
+    display: block;
+    font-family: var(--font-display);
+    font-size: 0.9em;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--rust);
+    text-decoration: none;
+    margin-bottom: 14px;
+    padding-bottom: 12px;
+    border-bottom: 2px solid var(--border-color);
+  }
+
+  .lib-sidebar-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .lib-sidebar-link {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px;
+    color: var(--text-primary);
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 0.95em;
+    border: 2px solid transparent;
+    transition: all 0.15s ease;
+  }
+
+  .lib-sidebar-link:hover {
+    border-color: var(--border-color);
+    color: var(--rust);
+  }
+
+  .lib-sidebar-link.is-active {
+    background: var(--tint-rust-2);
+    border-color: var(--rust);
+    color: var(--rust);
+    font-weight: 600;
+  }
+
+  .lib-sidebar-count {
+    font-size: 0.8em;
+    font-weight: 600;
+    color: var(--text-secondary);
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    padding: 1px 8px;
+    min-width: 24px;
+    text-align: center;
+  }
+</style>

--- a/src/components/library/entry-card.astro
+++ b/src/components/library/entry-card.astro
@@ -1,0 +1,105 @@
+---
+import type { LibraryEntry } from '../../lib/library';
+import { entryUrl, typeLabel } from '../../lib/library';
+
+interface Props {
+  entry: LibraryEntry;
+}
+
+const { entry } = Astro.props;
+const { name, tagline, type, access } = entry.data;
+---
+
+<a href={entryUrl(entry)} class="lib-card">
+  <div class="lib-card-badges">
+    <span class="lib-badge lib-badge-type">{typeLabel(type)}</span>
+    <span class={`lib-badge lib-badge-access lib-badge-${access}`}>
+      {access === 'free' ? 'Free' : 'Paid'}
+    </span>
+  </div>
+  <h3 class="lib-card-name">{name}</h3>
+  <p class="lib-card-tagline">{tagline}</p>
+  <span class="lib-card-link">Open {typeLabel(type).toLowerCase()}</span>
+</a>
+
+<style>
+  .lib-card {
+    display: flex;
+    flex-direction: column;
+    border: 2px solid var(--border-color);
+    background: var(--bg-secondary);
+    padding: 24px;
+    text-decoration: none;
+    color: var(--text-primary);
+    box-shadow: var(--shadow-sm);
+    transition: all 0.25s ease;
+    height: 100%;
+  }
+
+  .lib-card:hover {
+    transform: translate(-4px, -4px);
+    box-shadow: 8px 8px 0 var(--mustard);
+    border-color: var(--rust);
+  }
+
+  .lib-card-badges {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 14px;
+    flex-wrap: wrap;
+  }
+
+  .lib-badge {
+    font-size: 0.7em;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 3px 10px;
+    border: 1px solid var(--border-color);
+  }
+
+  .lib-badge-type {
+    background: var(--plum);
+    color: #fff;
+    border-color: var(--plum);
+  }
+
+  .lib-badge-free {
+    background: var(--tint-rust-2);
+    color: var(--rust);
+    border-color: var(--rust);
+  }
+
+  .lib-badge-paid {
+    background: var(--mustard);
+    color: var(--ink-on-mustard);
+    border-color: var(--ink-on-mustard);
+  }
+
+  .lib-card-name {
+    font-family: var(--font-display);
+    font-size: 1.25em;
+    margin: 0 0 8px;
+    line-height: 1.2;
+    color: var(--text-primary);
+  }
+
+  .lib-card-tagline {
+    font-size: 0.92em;
+    color: var(--text-secondary);
+    line-height: 1.5;
+    margin: 0 0 16px;
+    flex: 1;
+  }
+
+  .lib-card-link {
+    font-size: 0.85em;
+    font-weight: 600;
+    color: var(--rust);
+    margin-top: auto;
+  }
+
+  .lib-card:hover .lib-card-link {
+    text-decoration: underline;
+  }
+</style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -45,6 +45,9 @@ const libraryCollection = defineCollection({
     author: z.enum(['tri-vo', 'alice-marketer']),
     tags: z.array(z.string()).default([]),
     updatedAt: z.coerce.date().optional(),
+    publishedAt: z.coerce.date().optional(),
+    metaDescription: z.string().max(160).optional(),
+    faq: z.array(z.object({ q: z.string(), a: z.string() })).optional(),
   }),
 });
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -15,6 +15,40 @@ const modulesCollection = defineCollection({
   }),
 });
 
+// Marketing Library: curated prompts, slash commands, subagents, MCP lists, and
+// skills for marketers using Claude Code. Free entries ship now; the paid fields
+// (access/polarProductId/polarCheckoutUrl/price) sit ready so paid packs drop in
+// later with no schema change once Polar is wired up.
+const libraryCollection = defineCollection({
+  loader: glob({ pattern: '**/*.mdx', base: './src/content/library' }),
+  schema: z.object({
+    name: z.string(),
+    category: z.enum([
+      'seo',
+      'content',
+      'paid-ads',
+      'analytics',
+      'email',
+      'social',
+      'reporting',
+      'competitive',
+      'project-ops',
+    ]),
+    type: z.enum(['prompt', 'command', 'subagent', 'mcp', 'skill']),
+    tagline: z.string().max(90),
+    description: z.string(),
+    access: z.enum(['free', 'paid']).default('free'),
+    polarProductId: z.string().optional(),
+    polarCheckoutUrl: z.string().optional(),
+    price: z.number().optional(),
+    related: z.array(z.string()).default([]),
+    author: z.enum(['tri-vo', 'alice-marketer']),
+    tags: z.array(z.string()).default([]),
+    updatedAt: z.coerce.date().optional(),
+  }),
+});
+
 export const collections = {
   modules: modulesCollection,
+  library: libraryCollection,
 };

--- a/src/content/library/analytics/ga4-question-answerer.mdx
+++ b/src/content/library/analytics/ga4-question-answerer.mdx
@@ -1,0 +1,53 @@
+---
+name: GA4 Question Answerer
+category: analytics
+type: prompt
+tagline: Turn a plain English analytics question into GA4 exploration steps.
+description: A prompt that translates a plain English analytics question into the exact GA4 steps to answer it, naming which dimensions to pick, which metrics to add, which filters to set, and how to read the result.
+access: free
+related:
+  - weekly-metrics-summary
+  - serp-intent-classifier
+  - competitor-page-teardown
+author: tri-vo
+tags:
+  - analytics
+  - ga4
+  - prompt
+  - reporting
+updatedAt: 2026-07-21
+---
+
+The hard part of GA4 is not the data, it is knowing which report holds the answer. This prompt takes a question in plain English and returns a build sheet: the exploration type, the dimensions, the metrics, the filters, and the segment to compare against, plus how to read what comes back. It turns a vague question into steps you can follow inside GA4.
+
+## The prompt
+
+```text
+You are a GA4 analyst. I will ask a marketing question in plain English. Turn
+it into concrete steps to answer it in GA4 (Google Analytics 4). For each
+question, return:
+
+1. Restated question: what we are actually measuring, in one sentence.
+2. Report or exploration: which GA4 area to use (a standard report, or a Free
+   form / Funnel / Path exploration).
+3. Dimensions: the exact dimensions to add (e.g. Session default channel group,
+   Landing page, Country).
+4. Metrics: the exact metrics to add (e.g. Sessions, Conversions, Engagement
+   rate, Total revenue).
+5. Filters and segments: any filters to apply and any segment to compare against.
+6. Date range: what range fits the question.
+7. How to read it: what a good result looks like and one trap to avoid (for
+   example, do not confuse users with sessions).
+
+If the question is ambiguous or needs an event that may not be configured, say
+so and state your assumption. Keep it to the steps, no filler.
+
+My question: [type your analytics question here]
+```
+
+## How to use
+
+1. Paste the prompt into Claude Code and replace the last line with your question.
+2. Follow the steps inside GA4: add the dimensions and metrics exactly as listed.
+3. Read the "How to read it" note before you draw a conclusion, it flags the common traps.
+4. Feed the numbers you find into the Weekly Metrics Summary to write the readout.

--- a/src/content/library/analytics/ga4-question-answerer.mdx
+++ b/src/content/library/analytics/ga4-question-answerer.mdx
@@ -16,6 +16,15 @@ tags:
   - prompt
   - reporting
 updatedAt: 2026-07-21
+publishedAt: 2026-07-21
+metaDescription: "GA4 prompt that turns a plain English question into exact exploration steps: which dimensions, metrics, filters, and how to read the result."
+faq:
+  - q: "What does the GA4 Question Answerer output?"
+    a: "A build sheet for one question: the exploration type, the exact dimensions and metrics to add, filters and segments, a date range, and a note on how to read the result. You follow it step by step inside GA4."
+  - q: "What if my question needs an event that is not configured?"
+    a: "The prompt flags it and states its assumption instead of guessing. Check whether the event exists in your GA4 setup before you trust the numbers."
+  - q: "How does it pair with the Weekly Metrics Summary?"
+    a: "Use this prompt to find the right numbers in GA4, then feed those numbers into the Weekly Metrics Summary to write the stakeholder readout."
 ---
 
 The hard part of GA4 is not the data, it is knowing which report holds the answer. This prompt takes a question in plain English and returns a build sheet: the exploration type, the dimensions, the metrics, the filters, and the segment to compare against, plus how to read what comes back. It turns a vague question into steps you can follow inside GA4.

--- a/src/content/library/analytics/utm-builder.mdx
+++ b/src/content/library/analytics/utm-builder.mdx
@@ -1,0 +1,77 @@
+---
+name: UTM Builder
+category: analytics
+type: command
+tagline: Build consistent UTM tagged URLs from your naming rules and flag drift.
+description: "A /utm slash command that builds UTM tagged campaign URLs from a fixed naming convention and flags inconsistent tags, so your GA4 reports stay clean instead of splitting one campaign across five spellings."
+access: free
+related:
+  - ga4-question-answerer
+  - negative-keyword-finder
+  - monthly-report-outline
+author: tri-vo
+tags:
+  - analytics
+  - utm
+  - slash command
+updatedAt: 2026-07-21
+publishedAt: 2026-07-21
+metaDescription: "Build consistent UTM tagged URLs with Claude Code. Enforces a naming convention, lowercases tags, and flags inconsistent source or medium values."
+faq:
+  - q: Why do UTMs need a naming convention?
+    a: "GA4 treats Facebook, facebook, and FB as three different sources, so one campaign splits across rows and no channel adds up. A convention (lowercase, fixed source and medium vocab, hyphen separators) keeps every link in the same buckets so reports stay readable."
+  - q: Can it check links I already built?
+    a: "Yes. Paste existing tagged URLs and the command audits them against the rules: it flags casing drift, freeform source or medium values, spaces, and missing required tags, then returns a corrected version of each so you can fix links already in the wild."
+  - q: What are the standard medium values?
+    a: "The command defaults to the common set (cpc, email, social, organic, referral, affiliate, display) and rejects anything outside your allowed list unless you extend it, which is what stops one person writing e-mail and another writing newsletter for the same channel."
+---
+
+UTM tags fall apart the moment two people write them freehand: Facebook and facebook and FB become three sources, and a campaign no longer sums in GA4. This command builds every link against one naming convention (lowercase, a fixed source and medium vocabulary, hyphen separators) and audits links you already have, flagging casing drift, freeform values, and missing tags. Reports stay clean because the links were clean going in.
+
+## The command
+
+Save this as `.claude/commands/utm.md` in your project.
+
+```markdown
+---
+description: Build and audit UTM tagged URLs against a naming convention.
+argument-hint: [base URL plus source, medium, campaign] or [paste links to audit]
+---
+
+You are an analytics engineer enforcing UTM hygiene. Input: $ARGUMENTS
+
+House naming convention (apply and enforce all of it):
+- Lowercase everything. No spaces: use hyphens inside a value.
+- utm_source: the specific platform (google, facebook, linkedin, newsletter,
+  partner-acme). One canonical spelling each.
+- utm_medium: from this allowed set only: cpc, email, social, organic,
+  referral, affiliate, display. Reject anything else and suggest the closest.
+- utm_campaign: format {yyyy-mm}-{short-name} (for example 2026-07-summer-sale).
+- utm_content: optional, for splitting variants (ad-a, ad-b, header-cta).
+- utm_term: optional, for paid keywords only.
+
+Two modes, pick by the input:
+
+BUILD MODE (a base URL plus tag values):
+- Output the full tagged URL on one line, ready to copy.
+- Below it, list the final tag values so I can confirm.
+- If a required tag (source, medium, campaign) is missing, ask before building.
+
+AUDIT MODE (one or more existing tagged URLs pasted):
+- For each URL, give a table: Tag, Value, Verdict (ok / fix), Corrected value.
+- Flag: uppercase, spaces, a medium outside the allowed set, a source with a
+  known variant spelling, a campaign not matching the date-name format, and
+  any missing required tag.
+- Then output the corrected URL on one line.
+
+Always end with one line: the canonical source and medium these links roll up
+to, so I can confirm they land in one bucket in GA4.
+```
+
+## How to use
+
+1. Save the block above as `.claude/commands/utm.md`.
+2. To build: run `/utm` with the base URL and your source, medium, and campaign values.
+3. To audit: run `/utm` and paste links you already published to catch casing and vocabulary drift.
+4. Paste the built URL into your ad, email, or social scheduler.
+5. Keep the allowed medium set and source spellings in the command so every teammate builds to the same rules.

--- a/src/content/library/competitive/competitor-page-teardown.mdx
+++ b/src/content/library/competitive/competitor-page-teardown.mdx
@@ -16,6 +16,15 @@ tags:
   - prompt
   - positioning
 updatedAt: 2026-07-21
+publishedAt: 2026-07-21
+metaDescription: "Competitor teardown prompt that breaks one landing page into positioning, offer, proof, CTAs, and gaps, so five rivals line up for comparison."
+faq:
+  - q: "Why run the teardown on several competitors instead of one?"
+    a: "The prompt uses the same seven dimensions every time, so five teardowns line up side by side. Gaps that repeat across competitors are your clearest positioning opening."
+  - q: "What dimensions does it cover?"
+    a: "Positioning, offer, proof, message hierarchy, calls to action, gaps and openings, and a one-sentence takeaway. Every competitor gets scored on the same set so comparisons stay honest."
+  - q: "What if the competitor page is thin or behind a signup wall?"
+    a: "The prompt says so rather than inventing detail. Paste the copy you can access, or note what is gated, and it works with what is there."
 ---
 
 Staring at a rival page for an hour rarely produces a clear read. This prompt runs a fixed teardown on one competitor landing page: how they position, what they offer, the proof they lean on, their calls to action, and the gaps you could exploit. Because the lens is the same every time, five teardowns line up for comparison instead of drifting into five different write ups.

--- a/src/content/library/competitive/competitor-page-teardown.mdx
+++ b/src/content/library/competitive/competitor-page-teardown.mdx
@@ -1,0 +1,54 @@
+---
+name: Competitor Page Teardown
+category: competitive
+type: prompt
+tagline: Analyze one competitor landing page for offer, proof, CTA, and gaps.
+description: A prompt that tears down one competitor landing page on a fixed set of dimensions (positioning, offer, proof, calls to action, and gaps), so you get a consistent breakdown you can compare across several competitors.
+access: free
+related:
+  - ad-copy-variants
+  - serp-intent-classifier
+  - content-brief-generator
+author: tri-vo
+tags:
+  - competitive
+  - landing page
+  - prompt
+  - positioning
+updatedAt: 2026-07-21
+---
+
+Staring at a rival page for an hour rarely produces a clear read. This prompt runs a fixed teardown on one competitor landing page: how they position, what they offer, the proof they lean on, their calls to action, and the gaps you could exploit. Because the lens is the same every time, five teardowns line up for comparison instead of drifting into five different write ups.
+
+## The prompt
+
+```text
+You are a positioning strategist tearing down a competitor's landing page. I
+will give you the page (a URL or pasted copy). Analyze it on these dimensions,
+in this order:
+
+1. Positioning: who they say the product is for and the core promise, in their
+   own framing. Quote the headline.
+2. Offer: what they are actually selling, the pricing model if shown, and the
+   primary action they want.
+3. Proof: the evidence they use to be believed (logos, numbers, testimonials,
+   case studies, guarantees). Note how strong or thin it is.
+4. Message hierarchy: the order they make their argument in, and the one
+   benefit they lead with.
+5. Calls to action: every CTA, its wording, and where it sits on the page.
+6. Gaps and openings: 3 to 5 things they do weakly or not at all, that you
+   could win on (an unanswered objection, a missing proof type, a vague offer).
+7. One sentence takeaway: the single most useful thing to learn from this page.
+
+Be specific and quote the page where you can. Do not flatter or trash it,
+describe what is there. If the page is behind a wall or thin, say so.
+
+The page: [paste the URL or the landing page copy]
+```
+
+## How to use
+
+1. Paste the prompt into Claude Code and add the competitor URL or page copy.
+2. Run the same prompt across 3 to 5 competitors so the teardowns line up.
+3. Read the Gaps sections together: repeated gaps are your positioning opening.
+4. Feed the strongest opening into the Ad Copy Variant Generator to test messaging.

--- a/src/content/library/competitive/content-gap-finder.mdx
+++ b/src/content/library/competitive/content-gap-finder.mdx
@@ -1,0 +1,82 @@
+---
+name: Content Gap Finder
+category: competitive
+type: prompt
+tagline: Compare a competitor's topic coverage to yours and rank the gaps to target.
+description: "A prompt that maps a competitor's topic coverage against your own and returns a ranked list of content gaps: topics they rank for that you have not covered, scored by how worth chasing they are."
+access: free
+related:
+  - competitor-page-teardown
+  - content-brief-generator
+  - serp-intent-classifier
+author: tri-vo
+tags:
+  - competitive
+  - content strategy
+  - content gaps
+updatedAt: 2026-07-21
+publishedAt: 2026-07-21
+metaDescription: "Find content gaps against a competitor with Claude Code. Ranks topics they cover and you don't by relevance, intent, and effort to win."
+faq:
+  - q: How is this different from the competitor page teardown?
+    a: "The teardown reads one landing page in depth: offer, proof, CTA. This works at the topic-coverage level across both sites at once and returns a ranked list of what to write next. Use the teardown to study a page, use this to plan a content roadmap."
+  - q: What do I paste in?
+    a: "Two lists of topics or page titles: theirs and yours. A sitemap, a blog index, or an export of URL slugs works. You do not need full article text. The prompt compares coverage and clusters, so titles and slugs are enough to find the holes."
+  - q: How are the gaps ranked?
+    a: "Each gap is scored on relevance to your buyer, the search intent it serves, and rough effort to win, then sorted so the high-relevance, lower-effort topics rise to the top. The prompt also flags topics you should skip because they do not fit your audience."
+---
+
+Competitive content work stalls at "they just have more stuff." This prompt gets specific: paste their topic list and yours, and it maps coverage against coverage, then returns a ranked list of gaps (topics they cover that you do not) scored by relevance to your buyer, the intent served, and effort to win. It also flags the topics worth ignoring, so the roadmap chases winnable ground instead of matching a rival page for page.
+
+## The prompt
+
+```text
+You are a content strategist doing a coverage gap analysis. I will give you two
+lists of topics or page titles: a competitor's and mine.
+
+My business and buyer: [one line, for example: project management app for
+in-house creative teams].
+
+Do this:
+
+1. Cluster both lists into topic themes (for example: onboarding, pricing,
+   integrations, use cases, comparisons, thought leadership). Do not just match
+   titles word for word; group by the underlying topic.
+
+2. Build a coverage table by theme: Theme, They cover (yes / partial / no),
+   I cover (yes / partial / no), Gap type. Gap types: They have it and I do
+   not (true gap), We both have it (parity), I have it and they do not (my
+   edge).
+
+3. For every true gap, score it:
+   - Relevance to my buyer (high / med / low).
+   - Search intent it serves (informational, commercial, transactional).
+   - Effort to win (low / med / high), based on how deep the topic looks.
+   Then give a priority (chase now / chase later / skip) that favors high
+   relevance and lower effort.
+
+4. Output a ranked "Chase now" list: the specific pieces to create, each with
+   a working title, the intent it targets, and why it beats matching them.
+
+5. Flag any competitor topics I should deliberately skip because they do not
+   fit my buyer, so I do not copy their site out of reflex.
+
+6. End with my strongest existing edge (a theme I own that they do not) and how
+   to lean into it.
+
+Be specific and honest. If my list is thin in a theme that matters, say so.
+
+Their topics:
+[paste competitor page titles or slugs]
+
+My topics:
+[paste my page titles or slugs]
+```
+
+## How to use
+
+1. Pull both topic lists: their blog index or sitemap and yours (titles or URL slugs are enough).
+2. Paste the prompt, fill in the business and buyer line, and paste both lists.
+3. Read the Chase now list first, then sanity-check the Skip flags against your audience.
+4. Send the top gaps into the Content Brief Generator to turn each into a full brief.
+5. Re-run each quarter to catch new topics a competitor has started ranking for.

--- a/src/content/library/content/blog-post-outline.mdx
+++ b/src/content/library/content/blog-post-outline.mdx
@@ -16,6 +16,15 @@ tags:
   - slash command
   - writing
 updatedAt: 2026-07-21
+publishedAt: 2026-07-21
+metaDescription: "Blog outline command that turns a keyword into an H2 and H3 structure, tagging each section with the job it does and the search intent it serves."
+faq:
+  - q: "What do the parenthetical notes next to each H2 mean?"
+    a: "They name the job that section does for the reader: hook, context, main answer, objection, proof, or next step. Read them to check the primary intent is answered early, and reorder sections if it is not."
+  - q: "What does it produce besides the headings?"
+    a: "After the outline it lists three questions the post must answer to be complete and suggests one visual or example per main section, so a writer can start without more direction."
+  - q: "How does it differ from the Content Brief Generator?"
+    a: "This command is a fast structural outline from a keyword or title. The Content Brief Generator adds intent labels, SERP notes, entities, internal links, and a word count for full SEO planning."
 ---
 
 The outline is where a blog post is won or lost. Get the structure right and the draft writes itself; get it wrong and no amount of editing saves it. This command turns a keyword into a full H2 and H3 outline and, next to each section, notes the job that section does for the reader. You approve the structure before anyone writes a sentence.

--- a/src/content/library/content/blog-post-outline.mdx
+++ b/src/content/library/content/blog-post-outline.mdx
@@ -1,0 +1,56 @@
+---
+name: Blog Post Outline Builder
+category: content
+type: command
+tagline: Turn a keyword into an H2 and H3 outline with intent notes.
+description: A /outline slash command that produces a structured H2 and H3 blog outline from a target keyword, with a note on each section explaining what job it does for the reader and the search intent.
+access: free
+related:
+  - content-brief-generator
+  - repurpose-blog-to-social
+  - brand-voice-memory
+author: alice-marketer
+tags:
+  - content
+  - blog outline
+  - slash command
+  - writing
+updatedAt: 2026-07-21
+---
+
+The outline is where a blog post is won or lost. Get the structure right and the draft writes itself; get it wrong and no amount of editing saves it. This command turns a keyword into a full H2 and H3 outline and, next to each section, notes the job that section does for the reader. You approve the structure before anyone writes a sentence.
+
+## The command
+
+Save this as `.claude/commands/outline.md` in your project.
+
+```markdown
+---
+description: Build an H2 and H3 blog outline with intent notes from a keyword.
+argument-hint: [target keyword or working title]
+---
+
+You are a content strategist outlining a blog post. The topic is: $ARGUMENTS
+
+Produce an outline using H2 and H3 headings. Rules:
+
+- Open with a one-line note on who the reader is and what they want.
+- Use H2s for main sections and H3s for sub-points under them.
+- Next to each H2, in parentheses, note the job it does: hook, context,
+  main answer, objection, proof, next step, and so on.
+- Order the sections so the primary intent is answered early, then supported.
+- Include one H2 near the end for a clear call to action.
+- After the outline, list 3 questions the post must answer to be complete,
+  and suggest one visual or example per main section.
+
+Keep the outline tight enough to hand to a writer without more explanation.
+If the topic is broad, note where you narrowed the scope and why.
+```
+
+## How to use
+
+1. Save the block above as `.claude/commands/outline.md`.
+2. Run `/outline how to run a product launch on a small budget`.
+3. Read the parenthetical job notes: reorder sections if the intent is not answered early enough.
+4. Approve the structure, then draft each section or hand the outline to a writer.
+5. When the post is live, run the Repurpose command to spin it into social copy.

--- a/src/content/library/content/brand-voice-memory.mdx
+++ b/src/content/library/content/brand-voice-memory.mdx
@@ -1,0 +1,59 @@
+---
+name: Brand Voice Memory Block
+category: content
+type: prompt
+tagline: A CLAUDE.md block that keeps every draft on brand across a project.
+description: A project memory block for CLAUDE.md that encodes your brand tone, voice rules, and banned words so everything Claude Code writes in that project stays consistent without re-explaining the brand each time.
+access: free
+related:
+  - blog-post-outline
+  - repurpose-blog-to-social
+  - linkedin-post-from-notes
+author: alice-marketer
+tags:
+  - content
+  - brand voice
+  - claude.md
+  - project memory
+updatedAt: 2026-07-21
+---
+
+Re-explaining your brand voice in every prompt is a tax you pay forever. Claude Code reads a `CLAUDE.md` file at the root of a project automatically, so a voice block placed there applies to every draft without you pasting it again. Fill in the placeholders once and the whole project inherits your tone.
+
+## The memory block
+
+Add this to `CLAUDE.md` at the root of your marketing project.
+
+```markdown
+## Brand voice
+
+Apply these rules to all copy you write in this project: blog posts, emails,
+social posts, ad copy, and page text.
+
+Personality: [describe the brand in 3 to 5 adjectives, e.g. direct, warm,
+technical but plain spoken].
+
+We sound like: [name a reference, e.g. a knowledgeable friend who respects the
+reader's time].
+
+Rules:
+- Write in [first person plural / second person]. Address the reader as "you".
+- Reading level: aim for [e.g. grade 7 to 9]. Short sentences over long ones.
+- Lead with the outcome, then the detail. No throat clearing.
+- Use concrete specifics (numbers, names, examples) over vague claims.
+- Format for scanning: short paragraphs, lists, and bold subheads.
+
+Never use: [list banned words and phrases, e.g. em dashes, "leverage",
+"seamless", "game changer", "in today's world", exclamation stacks].
+
+When unsure whether something is on brand, choose the plainer, more specific
+option. Show, do not hype.
+```
+
+## How to use
+
+1. Create or open `CLAUDE.md` at the root of your project.
+2. Paste the block and fill in every placeholder with your real brand details.
+3. Start a new Claude Code session so the file is picked up, then write as normal.
+4. Spot check the first few outputs and tighten the rules where the voice drifts.
+5. Commit `CLAUDE.md` so your whole team shares the same voice.

--- a/src/content/library/content/brand-voice-memory.mdx
+++ b/src/content/library/content/brand-voice-memory.mdx
@@ -16,6 +16,15 @@ tags:
   - claude.md
   - project memory
 updatedAt: 2026-07-21
+publishedAt: 2026-07-21
+metaDescription: "A CLAUDE.md brand voice block that keeps every draft on tone across a project, so you stop re-explaining voice rules and banned words each prompt."
+faq:
+  - q: "Where does the brand voice block go?"
+    a: "In a CLAUDE.md file at the root of your marketing project. Claude Code reads that file automatically at the start of a session, so the voice rules apply to every draft without pasting them again."
+  - q: "Do I need to restart Claude Code after adding it?"
+    a: "Yes. Start a new session so the CLAUDE.md file is picked up, then spot check the first few outputs and tighten the rules where the voice drifts."
+  - q: "What should the block actually contain?"
+    a: "Personality adjectives, a voice reference, concrete rules (person, reading level, formatting), and a banned words list. Fill in every placeholder with your real brand details rather than leaving the examples."
 ---
 
 Re-explaining your brand voice in every prompt is a tax you pay forever. Claude Code reads a `CLAUDE.md` file at the root of a project automatically, so a voice block placed there applies to every draft without you pasting it again. Fill in the placeholders once and the whole project inherits your tone.

--- a/src/content/library/content/repurpose-blog-to-social.mdx
+++ b/src/content/library/content/repurpose-blog-to-social.mdx
@@ -1,0 +1,62 @@
+---
+name: Blog to Social Repurposer
+category: content
+type: command
+tagline: Turn one blog post into a LinkedIn post, an X thread, and a carousel.
+description: A /repurpose slash command that takes one blog post and produces a LinkedIn post, an X thread, and Instagram carousel copy, each shaped for its platform instead of the same text pasted three times.
+access: free
+related:
+  - blog-post-outline
+  - linkedin-post-from-notes
+  - newsletter-from-link
+author: alice-marketer
+tags:
+  - content
+  - repurposing
+  - social media
+  - slash command
+updatedAt: 2026-07-21
+---
+
+Most repurposing is just the same paragraph pasted into three boxes. This command reads one blog post and rewrites it three ways, each shaped for how people actually read on that platform: a standalone LinkedIn post, a hook led X thread, and slide by slide carousel copy. One post becomes a week of distribution.
+
+## The command
+
+Save this as `.claude/commands/repurpose.md` in your project.
+
+```markdown
+---
+description: Repurpose one blog post into LinkedIn, X, and Instagram copy.
+argument-hint: [path to post file, or paste the post]
+---
+
+You are a social media editor. Read the blog post referenced here: $ARGUMENTS
+
+Produce three deliverables, each written natively for its platform, not the
+same text reused. Pull the single strongest idea from the post as the spine.
+
+1. LinkedIn post
+   - Hook in the first line (before the "see more" fold).
+   - 120 to 200 words, short lines, one idea per line group.
+   - End with a question or a soft call to action.
+
+2. X thread
+   - 5 to 7 posts. First post is a scroll stopping hook.
+   - Each post stands on its own but builds the argument.
+   - Last post links back to the full article and invites a reply.
+
+3. Instagram carousel
+   - 6 to 8 slides. Slide 1 is the hook, last slide is the CTA.
+   - One line of copy per slide, plus a short caption for the post.
+
+Keep the brand voice consistent across all three. Do not invent facts that
+are not in the post. If the post is thin on specifics, say so and suggest what
+detail would make each format stronger.
+```
+
+## How to use
+
+1. Save the block above as `.claude/commands/repurpose.md`.
+2. Run `/repurpose ./content/my-latest-post.md`, or paste the post text after the command.
+3. Review each format for platform fit: the LinkedIn hook and the X first post matter most.
+4. Schedule the three across the week rather than posting them all at once.

--- a/src/content/library/content/repurpose-blog-to-social.mdx
+++ b/src/content/library/content/repurpose-blog-to-social.mdx
@@ -16,6 +16,15 @@ tags:
   - social media
   - slash command
 updatedAt: 2026-07-21
+publishedAt: 2026-07-21
+metaDescription: "Repurpose command that turns one blog post into a native LinkedIn post, an X thread, and Instagram carousel copy, each shaped for its platform."
+faq:
+  - q: "Do the three formats just reuse the same text?"
+    a: "No. The command pulls one strong idea from the post as the spine, then rewrites it natively for each platform: a standalone LinkedIn post, a hook-led X thread, and slide-by-slide carousel copy."
+  - q: "Can it work from a file path?"
+    a: "Yes. Run /repurpose ./content/my-post.md and it reads the file, or paste the post text after the command. It will not invent facts that are not in the post."
+  - q: "Should I publish all three at once?"
+    a: "Space them across the week instead. One post becomes several days of distribution, and the LinkedIn hook and the X first line are the parts worth editing most."
 ---
 
 Most repurposing is just the same paragraph pasted into three boxes. This command reads one blog post and rewrites it three ways, each shaped for how people actually read on that platform: a standalone LinkedIn post, a hook led X thread, and slide by slide carousel copy. One post becomes a week of distribution.

--- a/src/content/library/email/newsletter-from-link.mdx
+++ b/src/content/library/email/newsletter-from-link.mdx
@@ -16,6 +16,15 @@ tags:
   - slash command
   - summarizing
 updatedAt: 2026-07-21
+publishedAt: 2026-07-21
+metaDescription: "Newsletter command that turns any link into a ready-to-send section in your voice, with three subject line options and one clear call to action."
+faq:
+  - q: "What exactly does the newsletter command return?"
+    a: "Three subject line options of 50 characters or fewer, a 90 to 150 word section that tells the reader what to do with the link (not just a summary), and one call to action with the link included."
+  - q: "Does it read the URL for me?"
+    a: "Yes. Give it a URL and it reads the page, or paste the article text directly. It attributes the source and will not invent facts that are not in it."
+  - q: "What if the source article is thin?"
+    a: "The command says what is missing and writes the honest version anyway, so you are not padding a weak link with filler."
 ---
 
 The weekly newsletter dies from the effort of writing it. This command shrinks the mechanical part: give it a link and it returns a tight newsletter section that keeps your voice, plus a subject line and one call to action. You still choose what to feature. It handles the shaping so a send stops eating an afternoon.

--- a/src/content/library/email/newsletter-from-link.mdx
+++ b/src/content/library/email/newsletter-from-link.mdx
@@ -1,0 +1,55 @@
+---
+name: Newsletter Section from a Link
+category: email
+type: command
+tagline: Summarize a URL into a newsletter section with subject line and CTA.
+description: A /newsletter slash command that turns any article or link into a ready to send newsletter section, including a subject line option and a single clear call to action, in your own voice.
+access: free
+related:
+  - repurpose-blog-to-social
+  - linkedin-post-from-notes
+  - weekly-metrics-summary
+author: alice-marketer
+tags:
+  - email
+  - newsletter
+  - slash command
+  - summarizing
+updatedAt: 2026-07-21
+---
+
+The weekly newsletter dies from the effort of writing it. This command shrinks the mechanical part: give it a link and it returns a tight newsletter section that keeps your voice, plus a subject line and one call to action. You still choose what to feature. It handles the shaping so a send stops eating an afternoon.
+
+## The command
+
+Save this as `.claude/commands/newsletter.md` in your project.
+
+```markdown
+---
+description: Turn a link into a newsletter section with subject line and CTA.
+argument-hint: [URL or pasted article]
+---
+
+You are writing a section for a marketing newsletter. The source is: $ARGUMENTS
+
+If given a URL, read it. Then produce:
+
+1. Subject line: 3 options, each 50 characters or fewer, curiosity or benefit
+   led, no clickbait.
+2. Section body: 90 to 150 words. Open with why this matters to the reader,
+   then the 2 or 3 things worth knowing, in plain language. Do not just
+   summarize the source, tell the reader what to do with it.
+3. Call to action: one line, one action (read the full piece, try the tool,
+   reply with a take). Include the link.
+
+Keep the voice conversational and specific. Attribute the source. Do not
+invent facts that are not in the source. If the source is thin, say what is
+missing and write the honest version anyway.
+```
+
+## How to use
+
+1. Save the block above as `.claude/commands/newsletter.md`.
+2. Run `/newsletter https://example.com/the-article-you-are-featuring`.
+3. Pick one of the three subject lines, or ask for more in a different angle.
+4. Edit the body to add your own take, then drop it into your email tool.

--- a/src/content/library/email/welcome-sequence-outline.mdx
+++ b/src/content/library/email/welcome-sequence-outline.mdx
@@ -1,0 +1,76 @@
+---
+name: Welcome Sequence Outline
+category: email
+type: command
+tagline: Outline a 4 to 5 email onboarding drip with goal, subject, and CTA per email.
+description: "A /welcome-sequence slash command that outlines a 4 to 5 email onboarding drip: each email gets a goal, subject line, body beats, and one CTA, so new subscribers get a real journey instead of a single welcome note."
+access: free
+related:
+  - newsletter-from-link
+  - ad-copy-variants
+  - weekly-social-plan
+author: alice-marketer
+tags:
+  - email
+  - onboarding
+  - drip sequence
+updatedAt: 2026-07-21
+publishedAt: 2026-07-21
+metaDescription: "Outline a 4 to 5 email welcome sequence with Claude Code. Each email gets a goal, subject line, body beats, send delay, and one CTA."
+faq:
+  - q: How many emails should a welcome sequence have?
+    a: "Four to five is the workable default this command targets: welcome and set expectations, deliver a quick win, handle the top objection, share proof, then make the ask. Fewer than four rushes the trust build. More than five usually repeats itself."
+  - q: How is this different from the newsletter command?
+    a: "The newsletter command turns one link into one broadcast issue. This plans a whole automated sequence that runs on send delays after signup, with a distinct goal per email that moves someone from new subscriber toward first purchase or activation."
+  - q: Does it write finished email copy?
+    a: "It writes the outline: goal, subject options, body beats, and CTA per email, plus a send delay. That is the layer worth reviewing before anyone drafts. Expand a single email into full copy in a follow up pass once the arc is approved."
+---
+
+Most welcome flows are one email that says "thanks for subscribing" and then silence. This command outlines the whole arc instead: 4 to 5 emails, each with a clear goal, subject line options, the beats the body should hit, a send delay, and one call to action. You review the journey as a shape (does it build trust before it asks?) before anyone writes a word of final copy.
+
+## The command
+
+Save this as `.claude/commands/welcome-sequence.md` in your project.
+
+```markdown
+---
+description: Outline a 4 to 5 email welcome and onboarding sequence.
+argument-hint: [product, audience, the signup source, and the sequence goal]
+---
+
+You are a lifecycle email strategist. The brief is: $ARGUMENTS
+
+If the product, audience, where people signed up, or the goal of the sequence
+(for example first purchase, activation, first login) is missing, ask for it
+first. Then outline a 4 to 5 email welcome sequence.
+
+For each email, give:
+- Email number and its single goal in one line.
+- Send delay from the previous step (for example: immediately, day 2, day 4).
+- Two subject line options, written to be opened, not clever for its own sake.
+- Body beats: 3 to 5 bullet points for what the email covers, in order.
+- One CTA: the exact action and where it points.
+
+Arc to follow across the sequence:
+1. Welcome and set expectations: confirm what they get and how often.
+2. Deliver a quick win or the single most useful thing right away.
+3. Handle the top objection or friction that stops people acting.
+4. Show proof (a result, a case, a number, a testimonial).
+5. Make the ask: the primary conversion, with a reason to act now.
+
+If four emails fit better than five, merge steps 3 and 4 and say so.
+
+Rules:
+- One goal and one CTA per email. Do not stack asks.
+- Keep it specific to the product and audience, not generic onboarding filler.
+- End with a short note on what should happen when the sequence finishes
+  (move to the main list, tag as engaged, or enter a nurture track).
+```
+
+## How to use
+
+1. Save the block above as `.claude/commands/welcome-sequence.md`.
+2. Run `/welcome-sequence` and describe the product, audience, signup source, and goal.
+3. Read the goals column top to bottom: the sequence should build trust before the ask in the last email.
+4. Adjust send delays to match your tool, then build the automation.
+5. Draft each email's full copy in a follow up pass, one email at a time.

--- a/src/content/library/paid-ads/ad-copy-variants.mdx
+++ b/src/content/library/paid-ads/ad-copy-variants.mdx
@@ -16,6 +16,15 @@ tags:
   - slash command
   - a/b testing
 updatedAt: 2026-07-21
+publishedAt: 2026-07-21
+metaDescription: "Ad copy command that generates 10 headline and primary text variants for one offer, each tagged with a distinct angle, ready to drop into a test."
+faq:
+  - q: "How are the 10 variants different from each other?"
+    a: "Each plays a different angle: pain, outcome, proof, curiosity, objection, speed, urgency, comparison, identity, and direct offer. That gives a paid test real spread instead of ten rewordings."
+  - q: "What length are the headlines and primary text?"
+    a: "Headlines are 30 characters or fewer and primary text is 125 characters or fewer, sized for most ad platforms. Each variant is labeled with its angle, and the command names the three to test first."
+  - q: "Does it make up numbers or testimonials?"
+    a: "No. It keeps claims honest and uses a placeholder like [X%] where a figure would go. Swap in your real numbers before publishing."
 ---
 
 Paid performance comes from testing distinct angles, not ten versions of the same sentence. This command takes one offer and returns ten headline and primary text variants, each labeled with the angle it plays: pain, proof, curiosity, urgency, and so on. You get a batch with real spread that you can drop straight into your ad platform and test.

--- a/src/content/library/paid-ads/ad-copy-variants.mdx
+++ b/src/content/library/paid-ads/ad-copy-variants.mdx
@@ -1,0 +1,65 @@
+---
+name: Ad Copy Variant Generator
+category: paid-ads
+type: command
+tagline: Generate 10 headline and primary text variants, each with an angle.
+description: A /ad-variants slash command that produces 10 distinct headline and primary text variants for one offer, each tagged with the angle it plays, so a paid test starts with real variety instead of ten rewordings.
+access: free
+related:
+  - meta-title-description-writer
+  - competitor-page-teardown
+  - linkedin-post-from-notes
+author: tri-vo
+tags:
+  - paid ads
+  - ad copy
+  - slash command
+  - a/b testing
+updatedAt: 2026-07-21
+---
+
+Paid performance comes from testing distinct angles, not ten versions of the same sentence. This command takes one offer and returns ten headline and primary text variants, each labeled with the angle it plays: pain, proof, curiosity, urgency, and so on. You get a batch with real spread that you can drop straight into your ad platform and test.
+
+## The command
+
+Save this as `.claude/commands/ad-variants.md` in your project.
+
+```markdown
+---
+description: Generate 10 angle labeled ad copy variants for one offer.
+argument-hint: [product, audience, and offer]
+---
+
+You are a direct response copywriter. The offer is: $ARGUMENTS
+
+If any of product, target audience, or the specific offer is missing, ask for
+it before writing. Then produce 10 ad variants. Each variant must play a
+DIFFERENT angle. Use these angles, one per variant:
+
+1. Pain (name the problem)
+2. Outcome (paint the after state)
+3. Proof (a result, number, or testimonial style claim)
+4. Curiosity (an open loop)
+5. Objection (handle the top reason they hesitate)
+6. Speed or ease (how little effort it takes)
+7. Urgency or scarcity (a real reason to act now)
+8. Comparison (versus the old way or an alternative)
+9. Us and them (the identity the reader steps into)
+10. Direct offer (state the deal plainly)
+
+For each variant output:
+
+Angle: [the angle name]
+Headline: [30 characters or fewer]
+Primary text: [125 characters or fewer]
+
+Keep claims honest, do not invent specific numbers, use a placeholder like
+[X%] if you need one. After the 10, name the 3 you would test first and why.
+```
+
+## How to use
+
+1. Save the block above as `.claude/commands/ad-variants.md`.
+2. Run `/ad-variants` and describe your product, audience, and offer.
+3. Swap any [X%] placeholders for your real numbers before publishing.
+4. Launch the 3 recommended angles first, then test the rest against the winner.

--- a/src/content/library/paid-ads/negative-keyword-finder.mdx
+++ b/src/content/library/paid-ads/negative-keyword-finder.mdx
@@ -1,0 +1,77 @@
+---
+name: Negative Keyword Finder
+category: paid-ads
+type: prompt
+tagline: Mine a Google Ads search terms export for negative keywords, grouped by reason.
+description: "A prompt that reads a Google Ads search terms export and proposes a negative keyword list grouped by why each term wastes spend, so you cut irrelevant clicks without hiding queries that actually convert."
+access: free
+related:
+  - ad-copy-variants
+  - serp-intent-classifier
+  - utm-builder
+author: tri-vo
+tags:
+  - paid ads
+  - google ads
+  - negative keywords
+updatedAt: 2026-07-21
+publishedAt: 2026-07-21
+metaDescription: "Find negative keywords from a Google Ads search terms report with Claude Code. Grouped by reason, with match type and a do-not-block list."
+faq:
+  - q: What data does this prompt need?
+    a: "Your Google Ads search terms report exported as CSV, with at least the search term, clicks, cost, and conversions columns. Impressions and CTR help but are optional. Paste the rows or attach the file so the prompt can weigh spend against results before flagging anything."
+  - q: Will it block terms that are actually converting?
+    a: "No. The prompt is told to protect any term with conversions and to output a separate do-not-block list of borderline queries, so you never negate a search that quietly brings in sales just because it looks off-topic."
+  - q: What match type does it recommend?
+    a: "It suggests phrase or exact negatives for specific junk terms and broad negatives only for whole irrelevant themes, and it explains the choice per group so you are not pasting exact-match negatives that leak."
+---
+
+Search terms reports are where paid budgets quietly leak: clicks on queries that were never going to buy. This prompt reads your export and proposes a negative keyword list, but grouped by reason (wrong intent, wrong product, job seekers, free-seekers, competitor names, and so on) so you can approve whole buckets at once. It also protects anything with conversions and flags borderline terms as do-not-block, so cleanup does not cut into what works.
+
+## The prompt
+
+```text
+You are a paid search analyst cleaning up wasted spend. I will paste a Google
+Ads search terms report (CSV rows with search term, clicks, cost, conversions,
+and if present impressions and CTR).
+
+The product and its ideal buyer: [one line, for example: paid B2B invoicing
+software for small agencies].
+
+Do this:
+
+1. Scan every search term and judge relevance against the product and buyer
+   above, weighed against its cost and conversions.
+
+2. Propose negative keywords, grouped by the reason they waste spend. Use
+   groups like: Wrong intent (research or how-to only), Wrong product or
+   feature, Free or DIY seekers, Job and career seekers, Competitor brand
+   terms, Location or audience mismatch, Adult or unrelated. Add groups if the
+   data needs them.
+
+3. For each group, give a table: Search term, Clicks, Cost, Conversions,
+   Suggested negative, Match type (phrase, exact, or broad), Why.
+   - Suggest exact or phrase negatives for specific junk terms.
+   - Suggest a broad negative only for a whole irrelevant theme, and name the
+     root word.
+
+4. Protect performers: never propose negating any term that has conversions.
+
+5. Output a separate "Do not block yet" list: borderline terms that look
+   off-topic but have spend and no clear verdict, so I can watch them.
+
+6. End with the total clicks and cost the proposed negatives would have saved
+   in this report, and the single biggest waste theme.
+
+Be conservative: when a term could plausibly convert, leave it and explain.
+Here is the report:
+[paste the CSV rows]
+```
+
+## How to use
+
+1. In Google Ads, open the search terms report, set a meaningful date range, and export to CSV.
+2. Paste the prompt, fill in the product and buyer line, and paste the rows (or attach the file).
+3. Review group by group. Approve whole buckets, and spot-check the do-not-block list.
+4. Add the approved negatives at the right level (ad group, campaign, or a shared negative list) with the match types given.
+5. Re-run monthly on the fresh export so new waste themes get caught early.

--- a/src/content/library/project-ops/content-calendar-scaffold.mdx
+++ b/src/content/library/project-ops/content-calendar-scaffold.mdx
@@ -1,0 +1,60 @@
+---
+name: Content Calendar Scaffold
+category: project-ops
+type: command
+tagline: Build a 90 day rolling content calendar from a short description.
+description: A /calendar slash command that scaffolds a 90 day rolling content calendar with themes, cadence, and slots, so planning starts from a real structure instead of an empty spreadsheet.
+access: free
+related:
+  - blog-post-outline
+  - weekly-metrics-summary
+  - repurpose-blog-to-social
+author: alice-marketer
+tags:
+  - project ops
+  - content calendar
+  - slash command
+  - planning
+updatedAt: 2026-07-21
+---
+
+Planning stalls at the empty spreadsheet. This command scaffolds a 90 day rolling content calendar from a short description of your channels, cadence, and goals: monthly themes, weekly slots, and a starter idea in each slot. You start from a real structure and spend your time on the choices that actually differ, not on setting up the grid.
+
+## The command
+
+Save this as `.claude/commands/calendar.md` in your project.
+
+```markdown
+---
+description: Scaffold a 90 day rolling content calendar.
+argument-hint: [channels, cadence, audience, and goal]
+---
+
+You are a content operations lead. The brief is: $ARGUMENTS
+
+If channels, posting cadence, audience, or the quarter's goal is missing, ask
+for it first. Then build a 90 day rolling content calendar as a table.
+
+Structure:
+- Group by month, then by week (13 weeks total).
+- Give each month a theme tied to the goal.
+- For each week, create one row per channel in the cadence. Columns:
+  Week, Date range, Channel, Content type, Working title or idea, Status.
+- Set every Status to "Idea" so it is ready to fill in.
+- Seed each slot with a specific starter idea, not a placeholder, based on the
+  audience and goal. Vary the content types across the quarter.
+
+After the table:
+- List 3 evergreen ideas that can fill any gap.
+- Note one repurposing loop (for example, each blog post becomes 2 social posts
+  and 1 newsletter section).
+
+Keep it realistic for the stated cadence. Do not overload a small team.
+```
+
+## How to use
+
+1. Save the block above as `.claude/commands/calendar.md`.
+2. Run `/calendar` and describe your channels, cadence, audience, and quarterly goal.
+3. Copy the table into your planning tool and fill in owners and dates.
+4. Use the Blog Post Outline command to expand any slot into a full brief when it is up next.

--- a/src/content/library/project-ops/content-calendar-scaffold.mdx
+++ b/src/content/library/project-ops/content-calendar-scaffold.mdx
@@ -16,6 +16,15 @@ tags:
   - slash command
   - planning
 updatedAt: 2026-07-21
+publishedAt: 2026-07-21
+metaDescription: "Calendar command that scaffolds a 90 day rolling content calendar with monthly themes, weekly per-channel slots, and a real starter idea in each."
+faq:
+  - q: "What does the scaffold actually contain?"
+    a: "A 13 week table grouped by month, each month with a theme tied to your goal, one row per channel per week with columns for date range, content type, working title, and status, plus three evergreen gap-fillers and one repurposing loop."
+  - q: "Are the slots empty placeholders?"
+    a: "No. Each slot is seeded with a specific starter idea based on your audience and goal, with content types varied across the quarter. Every status starts at Idea so it is ready to fill in."
+  - q: "How do I turn a calendar slot into a real post?"
+    a: "When a slot comes up, run the Blog Post Outline command on its working title to expand it into a full structure a writer can follow."
 ---
 
 Planning stalls at the empty spreadsheet. This command scaffolds a 90 day rolling content calendar from a short description of your channels, cadence, and goals: monthly themes, weekly slots, and a starter idea in each slot. You start from a real structure and spend your time on the choices that actually differ, not on setting up the grid.

--- a/src/content/library/project-ops/marketing-mcp-starter.mdx
+++ b/src/content/library/project-ops/marketing-mcp-starter.mdx
@@ -1,0 +1,71 @@
+---
+name: Marketing MCP Starter
+category: project-ops
+type: mcp
+tagline: A starter set of MCP servers marketers actually use with Claude Code.
+description: "A curated starter list of MCP servers for marketers using Claude Code: analytics, search data, social, and docs, each with what it does and a one-line setup note, so Claude can pull real data instead of guessing."
+access: free
+related:
+  - content-calendar-scaffold
+  - ga4-question-answerer
+  - utm-builder
+author: tri-vo
+tags:
+  - project ops
+  - mcp
+  - claude code setup
+updatedAt: 2026-07-21
+publishedAt: 2026-07-21
+metaDescription: "A starter list of MCP servers for marketers on Claude Code: analytics, search, social, and docs, each with a what-it-does line and setup note."
+faq:
+  - q: What is an MCP server, in marketing terms?
+    a: "An MCP server is a small connector that gives Claude Code live access to a tool you already use, like your analytics or a search API. Instead of pasting a CSV, Claude queries the source directly, so answers come from current data rather than what you happened to copy in."
+  - q: Do I need all of these?
+    a: "No. Start with one that removes a repeated copy-paste in your week, usually analytics or a docs connector. Add another only when a real task needs it. Every server you connect is one more thing to keep authorized and updated, so add on demand."
+  - q: Is it safe to connect these to my accounts?
+    a: "Connect read-only where the server offers it, use a scoped API key rather than an admin login, and prefer official or well-maintained servers. Review what each server can access before authorizing, the same way you would vet any third-party app touching your marketing stack."
+---
+
+Claude Code is far more useful when it can read your real data instead of whatever you pasted in. MCP servers are the connectors that make that happen: analytics, search data, social scheduling, and your docs. This is a starter set aimed at marketers, not engineers. Each entry says what it does and how to add it, so you can wire up one connector this week and stop copy-pasting exports.
+
+## The starter list
+
+Add servers with the Claude Code CLI. The general shape is:
+
+```bash
+# Add an MCP server (name it, then give the run command)
+claude mcp add <name> -- <command to start the server>
+
+# List what is connected
+claude mcp list
+
+# Remove one
+claude mcp remove <name>
+```
+
+### Analytics and data
+
+- **Google Analytics (GA4)** — Lets Claude query your GA4 property directly: sessions, conversions, traffic by channel, date ranges. What it removes: manual GA4 exports before every report. Setup note: use the official Google Analytics MCP server, authorize with a service account or OAuth scoped to read-only, and pass your property ID. Pair it with the GA4 Question Answerer prompt.
+- **PostgreSQL / database** — Read your own product or CRM tables (signups, orders, cohorts) so Claude can tie marketing activity to real outcomes. What it removes: pinging an engineer for a one-off number. Setup note: the reference `@modelcontextprotocol/server-postgres` works well. Connect with a read-only database user, never an admin role.
+
+### Search and web
+
+- **Web search (Brave or similar)** — Gives Claude live search results for SERP checks, competitor scanning, and fact-checking claims before they ship. What it removes: switching to a browser mid-task. Setup note: get an API key from the provider, add it as the server's env var. Free tiers cover light use.
+- **Fetch / web page reader** — Pulls the actual content of a URL so Claude can tear down a competitor page or summarize an article you paste as a link. What it removes: copying page text by hand. Setup note: the reference `fetch` server needs no API key and is the fastest first install.
+
+### Social and content
+
+- **Buffer or social scheduler (community MCP)** — Read your posting queue and past post performance so Claude can slot new content into real gaps. What it removes: cross-checking a spreadsheet against your scheduler. Setup note: use a community server that wraps your scheduler's API, authorize with an app-scoped token, and confirm it is read-plus-create only if you want Claude to draft into drafts, not publish.
+- **Notion or Google Docs** — Read and write your content calendar, briefs, and notes where the team already works. What it removes: retyping a brief out of Claude and into your doc tool. Setup note: official Notion and Google Workspace MCP servers exist. Scope access to the specific database or folder marketing uses, not the whole workspace.
+
+### Project and issues
+
+- **Linear or Jira** — Read the marketing project board so Claude can see what is shipping and when, and draft updates from real task status. What it removes: manually summarizing a board for a status note. Setup note: official servers exist for both. Authorize with a token scoped to the marketing team's project.
+
+## How to use
+
+1. Pick one server that kills a repeated copy-paste in your week (analytics or docs is the usual first).
+2. Run `claude mcp add ...` with the command from that server's README, then `claude mcp list` to confirm it connected.
+3. Ask Claude a question that needs the live data (for example, "which channel drove the most conversions last month?") to check the connection works end to end.
+4. Prefer read-only, scoped keys, and review what each server can touch before authorizing.
+5. Add a second server only when a real task needs it, not all at once.

--- a/src/content/library/reporting/monthly-report-outline.mdx
+++ b/src/content/library/reporting/monthly-report-outline.mdx
@@ -1,0 +1,81 @@
+---
+name: Monthly Report Outline
+category: reporting
+type: command
+tagline: Produce an executive monthly marketing report outline leaders will read.
+description: "A /monthly-report slash command that outlines an executive monthly marketing report: wins, metrics against target, learnings, and next month's plan, so the write-up starts structured instead of as a metric dump."
+access: free
+related:
+  - weekly-metrics-summary
+  - utm-builder
+  - ga4-question-answerer
+author: tri-vo
+tags:
+  - reporting
+  - executive report
+  - slash command
+updatedAt: 2026-07-21
+publishedAt: 2026-07-21
+metaDescription: "Outline an executive monthly marketing report with Claude Code. Wins, metrics vs target, learnings, and next month's plan in a leadership-ready shape."
+faq:
+  - q: How is this different from the weekly metrics summary?
+    a: "The weekly summary is a fast internal pulse for the team. This is a monthly report written for leadership: it frames results against targets, pulls out the two or three decisions that matter, and states next month's plan. It reads up the org, not across the team."
+  - q: What should I feed it?
+    a: "This month's numbers with their targets or prior-period values, your top two or three wins, anything that missed, and next month's priorities. The command turns that into the report shape. Vaguer input gives a vaguer report, so bring the actual figures."
+  - q: Does it write the whole report?
+    a: "It produces the outline and the framing (what each section should say and which numbers belong where), which is the part that takes judgment. You drop in the final numbers and one or two sentences of context per section, so a report that used to take an afternoon takes twenty minutes."
+---
+
+Monthly reports go wrong in two directions: a wall of metrics no leader reads, or a vibes update with no numbers. This command outlines the report leadership actually wants: the two or three wins that mattered, metrics set against their targets (not floating alone), the learnings that will change next month, and a short plan for what comes next. You start from a structure that reads up the org, then drop in your figures.
+
+## The command
+
+Save this as `.claude/commands/monthly-report.md` in your project.
+
+```markdown
+---
+description: Outline an executive monthly marketing report.
+argument-hint: [the month, key metrics with targets, wins, misses, next priorities]
+---
+
+You are a marketing lead writing the monthly report for the leadership team.
+Input: $ARGUMENTS
+
+If the month, the key metrics with their targets or prior values, the main
+wins, or next month's priorities are missing, ask for them first. Then produce
+the report outline in this order:
+
+1. Headline: one sentence on how the month went, tied to the goal. Then 3
+   bullet TL;DR points a busy exec can read in ten seconds.
+
+2. Wins: the 2 to 3 results that mattered most. For each, state what happened,
+   the number, and why it matters to the business (not just the channel).
+
+3. Metrics vs target: a table. Metric, Target, Actual, Delta, Status
+   (on track / ahead / behind). Only include metrics tied to a goal, not every
+   number available. Under the table, one line naming the single metric most
+   worth attention next month.
+
+4. What missed and why: anything behind target, stated plainly, with the most
+   likely cause. No blame, no burying it.
+
+5. Learnings: 2 to 3 things this month taught us that change what we do next.
+   Each learning must lead to a decision, not just an observation.
+
+6. Next month: the top 3 priorities, each with the outcome it targets and the
+   one metric that proves it worked.
+
+Rules:
+- Frame every number against a target or prior period. A number alone is not a
+  result.
+- Keep it to what a director would read start to finish. Cut vanity metrics.
+- Where I have not given a number, mark it [add number] rather than inventing.
+```
+
+## How to use
+
+1. Save the block above as `.claude/commands/monthly-report.md`.
+2. Run `/monthly-report` with the month, your key metrics and targets, wins, misses, and next priorities.
+3. Fill any `[add number]` gaps with the real figures from GA4 or your dashboard.
+4. Tighten the Learnings section: each learning should point to a decision, or cut it.
+5. Reuse the same structure every month so leadership learns where to look.

--- a/src/content/library/reporting/weekly-metrics-summary.mdx
+++ b/src/content/library/reporting/weekly-metrics-summary.mdx
@@ -1,0 +1,52 @@
+---
+name: Weekly Metrics Summary
+category: reporting
+type: prompt
+tagline: Turn a metrics CSV into a plain language weekly readout with deltas.
+description: A prompt that turns a raw metrics export into a plain language weekly readout, with week over week deltas called out and the noteworthy changes flagged, so a stakeholder can read it in a minute.
+access: free
+related:
+  - ga4-question-answerer
+  - content-calendar-scaffold
+  - newsletter-from-link
+author: tri-vo
+tags:
+  - reporting
+  - metrics
+  - prompt
+  - dashboards
+updatedAt: 2026-07-21
+---
+
+A grid of numbers is not a report. This prompt takes a metrics export and writes the recap: what moved, by how much, and what is worth a second look. It calls out the week over week deltas and flags the changes that matter instead of listing every row. You paste the numbers, you get a readout you can send with light edits.
+
+## The prompt
+
+```text
+You are a marketing analyst writing a weekly readout for a busy stakeholder.
+I will paste a metrics table (this week and last week, or a CSV). Produce:
+
+1. Headline: one sentence on the overall story of the week (up, down, flat,
+   and the main driver).
+2. What moved: a short list of the metrics that changed most, each with the
+   absolute value and the week over week change as both a number and a percent.
+   Mark each as good, bad, or watch.
+3. Why it likely moved: 1 to 2 plausible drivers per notable change, framed as
+   hypotheses, not certainties. Do not invent causes the data cannot support.
+4. Callouts: anything that needs a decision or a closer look this week.
+5. Next step: one concrete action for next week.
+
+Keep it under 200 words total. Plain language, no jargon, round numbers where
+it aids reading. If a metric is missing or looks like a tracking error, say so
+rather than guessing.
+
+Here is the data:
+[paste your metrics table or CSV]
+```
+
+## How to use
+
+1. Export your weekly metrics as a table or CSV (this week and last week side by side).
+2. Paste the prompt into Claude Code and drop your data in at the bottom.
+3. Check the "Why it likely moved" hypotheses against what you know before you send.
+4. Send the readout, or paste it into the Newsletter command if it goes to a wider list.

--- a/src/content/library/reporting/weekly-metrics-summary.mdx
+++ b/src/content/library/reporting/weekly-metrics-summary.mdx
@@ -16,6 +16,15 @@ tags:
   - prompt
   - dashboards
 updatedAt: 2026-07-21
+publishedAt: 2026-07-21
+metaDescription: "Reporting prompt that turns a metrics CSV into a plain language weekly readout, calling out week-over-week deltas and flagging what matters."
+faq:
+  - q: "What sections does the readout include?"
+    a: "A one-sentence headline, a What Moved list with each change as a number and a percent marked good, bad, or watch, likely drivers framed as hypotheses, callouts that need a decision, and one next step, all under 200 words."
+  - q: "How should I prepare the data?"
+    a: "Export this week and last week side by side as a table or CSV and paste it at the bottom of the prompt. If a metric is missing or looks like a tracking error, the prompt flags it instead of guessing."
+  - q: "Can I trust the Why It Moved explanations?"
+    a: "Treat them as hypotheses, not facts. The prompt is told not to invent causes the data cannot support, but check each driver against what you know before sending."
 ---
 
 A grid of numbers is not a report. This prompt takes a metrics export and writes the recap: what moved, by how much, and what is worth a second look. It calls out the week over week deltas and flags the changes that matter instead of listing every row. You paste the numbers, you get a readout you can send with light edits.

--- a/src/content/library/seo/content-brief-generator.mdx
+++ b/src/content/library/seo/content-brief-generator.mdx
@@ -1,0 +1,63 @@
+---
+name: Content Brief Generator
+category: seo
+type: command
+tagline: Turn one keyword into a full SEO content brief a writer can follow.
+description: A /content-brief slash command that builds a complete SEO content brief from a single target keyword, covering intent, SERP notes, an H2 and H3 outline, entities to cover, internal links, and a target word count.
+access: free
+related:
+  - serp-intent-classifier
+  - meta-title-description-writer
+  - blog-post-outline
+author: tri-vo
+tags:
+  - seo
+  - content brief
+  - slash command
+  - keyword research
+updatedAt: 2026-07-21
+---
+
+A content brief is the difference between a writer guessing and a writer executing. This slash command takes one target keyword and returns a brief that covers search intent, what the current top results do, the outline to beat them, the entities Google expects to see, internal links to add, and a word count grounded in the SERP. Save it once and every brief starts from the same structure.
+
+## The command
+
+Save this as `.claude/commands/content-brief.md` in your project.
+
+```markdown
+---
+description: Build a full SEO content brief from one target keyword.
+argument-hint: [target keyword]
+---
+
+You are an SEO strategist writing a content brief for a writer who has not
+researched this topic. The target keyword is: $ARGUMENTS
+
+Produce a brief with these sections, in this order:
+
+1. Target keyword and 3 to 5 secondary keywords or close variants.
+2. Search intent: label it informational, commercial, transactional, or
+   navigational, and explain in one sentence what the searcher wants.
+3. SERP notes: describe the likely content types ranking now (guides, listicles,
+   product pages, comparisons), the common angle, and one gap none of them cover.
+4. Recommended title and one-line meta description.
+5. Outline: an H2 and H3 structure that covers the topic more completely than a
+   typical top result. Mark which sections answer the primary intent.
+6. Entities and subtopics to include (people, tools, concepts, related terms
+   Google associates with this keyword). List 8 to 12.
+7. Internal links: describe 3 to 5 types of pages on the site that should link
+   to or from this article.
+8. Target word count, with a one-line rationale tied to the SERP.
+9. Three questions the article must answer to earn a featured snippet.
+
+Keep it scannable. Use lists, not paragraphs, wherever possible. If the keyword
+is ambiguous, state your assumption at the top and continue.
+```
+
+## How to use
+
+1. Save the block above as `.claude/commands/content-brief.md`.
+2. In Claude Code, run `/content-brief best crm for small teams` (swap in your keyword).
+3. Read the intent and SERP notes first: if the intent is wrong, refine the keyword and rerun.
+4. Hand the outline and entity list to your writer, or keep going and draft section by section.
+5. Pair it with the Meta Title and Description Writer to finish the on-page setup.

--- a/src/content/library/seo/content-brief-generator.mdx
+++ b/src/content/library/seo/content-brief-generator.mdx
@@ -16,6 +16,15 @@ tags:
   - slash command
   - keyword research
 updatedAt: 2026-07-21
+publishedAt: 2026-07-21
+metaDescription: "SEO content brief command that turns one keyword into intent, SERP notes, an outline, entities, internal links, and a word count a writer can follow."
+faq:
+  - q: "What sections does the brief include?"
+    a: "Target and secondary keywords, search intent, SERP notes with a gap to exploit, a recommended title and meta, an H2 and H3 outline, 8 to 12 entities to cover, 3 to 5 internal link types, a word count with rationale, and three snippet questions."
+  - q: "How is it different from the Blog Post Outline command?"
+    a: "The outline builder gives you a fast structure from a keyword. This brief adds the full SEO layer around it: intent, SERP analysis, entities, internal links, and a word count grounded in what ranks."
+  - q: "What do I do first with the output?"
+    a: "Read the intent and SERP notes. If the intent label is wrong, refine the keyword and rerun before handing the outline and entity list to a writer."
 ---
 
 A content brief is the difference between a writer guessing and a writer executing. This slash command takes one target keyword and returns a brief that covers search intent, what the current top results do, the outline to beat them, the entities Google expects to see, internal links to add, and a word count grounded in the SERP. Save it once and every brief starts from the same structure.

--- a/src/content/library/seo/meta-title-description-writer.mdx
+++ b/src/content/library/seo/meta-title-description-writer.mdx
@@ -1,0 +1,63 @@
+---
+name: Meta Title and Description Writer
+category: seo
+type: command
+tagline: Write SERP length checked title and description pairs that fit Google.
+description: A /meta slash command that generates title tags of 60 characters or fewer and meta descriptions of 155 characters or fewer, in matched pairs, with the character count shown so nothing truncates in search results.
+access: free
+related:
+  - content-brief-generator
+  - serp-intent-classifier
+  - blog-post-outline
+author: tri-vo
+tags:
+  - seo
+  - meta tags
+  - title tag
+  - slash command
+updatedAt: 2026-07-21
+---
+
+A great title tag that gets cut off at 61 characters is a wasted title tag. This command writes title and description pairs, checks the length of each, and shows the count so you can pick one that fits Google without truncation. It writes several options per page so you have variety to test.
+
+## The command
+
+Save this as `.claude/commands/meta.md` in your project.
+
+```markdown
+---
+description: Write SERP length checked title and meta description pairs.
+argument-hint: [page topic or target keyword]
+---
+
+You are an SEO copywriter. The page topic or target keyword is: $ARGUMENTS
+
+Write 5 title and meta description pairs for this page. Rules:
+
+- Title: 60 characters or fewer. Include the primary keyword near the front.
+  Make it click worthy, not clickbait.
+- Description: 155 characters or fewer. Expand on the title, add a specific
+  benefit or detail, and end with a light call to action.
+- Do not stuff keywords. Each pair should read like a human wrote it.
+- Vary the angle across the 5 pairs (benefit led, question led, how to led,
+  comparison led, urgency led).
+
+Format each pair like this:
+
+Pair 1
+Title (NN chars): the title text
+Description (NNN chars): the description text
+
+Replace NN and NNN with the actual character counts you measured. Count
+characters including spaces. If any line is over the limit, rewrite it before
+you output, do not output an over-limit line.
+
+After the 5 pairs, name which pair you would ship and why, in one sentence.
+```
+
+## How to use
+
+1. Save the block above as `.claude/commands/meta.md`.
+2. Run `/meta claude code for marketing teams` (swap in your page topic).
+3. Check the character counts: if a line looks long, ask Claude to tighten it.
+4. Drop the winning pair into your CMS or head tags, then move to the next page.

--- a/src/content/library/seo/meta-title-description-writer.mdx
+++ b/src/content/library/seo/meta-title-description-writer.mdx
@@ -16,6 +16,15 @@ tags:
   - title tag
   - slash command
 updatedAt: 2026-07-21
+publishedAt: 2026-07-21
+metaDescription: "Meta tag command that writes 5 title and description pairs, each length-checked with the character count shown, so nothing truncates in Google."
+faq:
+  - q: "What are the length limits it enforces?"
+    a: "Titles are 60 characters or fewer and descriptions are 155 or fewer. The command shows the measured character count on each line and rewrites any line that runs over before outputting it."
+  - q: "Why does it write five pairs?"
+    a: "To give you variety to test. Each pair takes a different angle (benefit, question, how-to, comparison, urgency), and the command names the one it would ship and why."
+  - q: "Should I trust the character counts?"
+    a: "Spot check them. The model measures and reports counts, but if a line looks long, ask it to tighten before you paste into your CMS or head tags."
 ---
 
 A great title tag that gets cut off at 61 characters is a wasted title tag. This command writes title and description pairs, checks the length of each, and shows the count so you can pick one that fits Google without truncation. It writes several options per page so you have variety to test.

--- a/src/content/library/seo/serp-intent-classifier.mdx
+++ b/src/content/library/seo/serp-intent-classifier.mdx
@@ -16,6 +16,15 @@ tags:
   - keyword research
   - prompt
 updatedAt: 2026-07-21
+publishedAt: 2026-07-21
+metaDescription: "SEO prompt that labels a keyword list by search intent with a reason for each call, then groups the keywords by the page type that fits."
+faq:
+  - q: "What are the four intent labels it uses?"
+    a: "Informational, commercial, transactional, and navigational. Each keyword gets one dominant label plus a one-line reason naming the signal, like best or vs for commercial, buy or pricing for transactional."
+  - q: "What is the Grouping section for?"
+    a: "After the table, it buckets keywords by intent and names the page type each bucket needs (a guide, comparison, landing page, or product page), so you know what to build before writing."
+  - q: "What happens to it next in the workflow?"
+    a: "Send the informational keywords to the Content Brief Generator to build article briefs. Transactional and commercial ones point to product or comparison pages instead."
 ---
 
 Ranking starts with matching intent. A transactional keyword needs a product or comparison page, not a 2,000 word guide. This prompt takes a raw keyword list and sorts it by intent, with a one-line reason for each call, so you can decide what kind of page each keyword deserves before you write a word.

--- a/src/content/library/seo/serp-intent-classifier.mdx
+++ b/src/content/library/seo/serp-intent-classifier.mdx
@@ -1,0 +1,55 @@
+---
+name: SERP Intent Classifier
+category: seo
+type: prompt
+tagline: Label a keyword list by search intent, with a reason for each call.
+description: A prompt that classifies a list of keywords by search intent (informational, commercial, transactional, or navigational) and gives a short reason for each label, so you can sort a keyword list into the right content types.
+access: free
+related:
+  - content-brief-generator
+  - meta-title-description-writer
+  - ga4-question-answerer
+author: tri-vo
+tags:
+  - seo
+  - search intent
+  - keyword research
+  - prompt
+updatedAt: 2026-07-21
+---
+
+Ranking starts with matching intent. A transactional keyword needs a product or comparison page, not a 2,000 word guide. This prompt takes a raw keyword list and sorts it by intent, with a one-line reason for each call, so you can decide what kind of page each keyword deserves before you write a word.
+
+## The prompt
+
+```text
+You are an SEO analyst. I will give you a list of keywords. For each keyword,
+classify the dominant search intent as one of:
+
+- informational (the searcher wants to learn or understand)
+- commercial (the searcher is comparing options before buying)
+- transactional (the searcher is ready to act, buy, sign up, download)
+- navigational (the searcher wants a specific brand, product, or page)
+
+Return a table with three columns: Keyword, Intent, Reason. The reason is one
+short sentence explaining the signal you used (modifiers like "best" or "vs"
+suggest commercial, "buy" or "pricing" suggest transactional, "how to" or
+"what is" suggest informational, a brand name suggests navigational).
+
+If a keyword could carry two intents, pick the dominant one and note the
+secondary intent in the reason. Do not skip any keyword.
+
+After the table, add a short section called "Grouping" that buckets the
+keywords by intent and, for each bucket, names the page type that fits best
+(guide, comparison, landing page, product page, and so on).
+
+Here is the list:
+[paste your keywords, one per line]
+```
+
+## How to use
+
+1. Paste the prompt into Claude Code and replace the last line with your keyword list.
+2. Read the Reason column to sanity check the calls: intent labels drive your whole content plan.
+3. Use the Grouping section to assign each bucket to a page type.
+4. Send informational keywords to the Content Brief Generator to build the article briefs.

--- a/src/content/library/social/linkedin-post-from-notes.mdx
+++ b/src/content/library/social/linkedin-post-from-notes.mdx
@@ -16,6 +16,15 @@ tags:
   - slash command
   - copywriting
 updatedAt: 2026-07-21
+publishedAt: 2026-07-21
+metaDescription: "LinkedIn command that turns rough bullet notes into a finished post with a scroll-stopping hook and a clear CTA, keeping the specifics intact."
+faq:
+  - q: "Will it keep the details from my notes?"
+    a: "Yes. The command is told to keep every specific (names, numbers, moments) rather than smoothing them into vague generalities, since real detail is what makes a post credible."
+  - q: "What length and format does it produce?"
+    a: "One post of 120 to 220 words with short lines for mobile, a hook as the first line, a fitting call to action, and at most three hashtags on their own line. It also gives one alternate first line to pick from."
+  - q: "How is it different from the Blog to Social repurposer?"
+    a: "This drafts a single post from your own rough notes. The repurposer starts from an existing blog post and produces LinkedIn, X, and Instagram copy at once."
 ---
 
 You have the idea in a few messy bullets. The gap is the drafting: the hook, the flow, the close. This command takes your rough notes and returns a LinkedIn post that keeps your specifics, opens with a line worth stopping for, and ends by asking for something. It drafts; you still make the final call on what to ship.

--- a/src/content/library/social/linkedin-post-from-notes.mdx
+++ b/src/content/library/social/linkedin-post-from-notes.mdx
@@ -1,0 +1,56 @@
+---
+name: LinkedIn Post from Notes
+category: social
+type: command
+tagline: Draft a LinkedIn post from rough bullet notes, with a hook and CTA.
+description: A /linkedin slash command that turns rough bullet notes into a finished LinkedIn post, complete with a scroll stopping first line and a clear call to action, while keeping the specifics that make a post credible.
+access: free
+related:
+  - repurpose-blog-to-social
+  - brand-voice-memory
+  - newsletter-from-link
+author: alice-marketer
+tags:
+  - social
+  - linkedin
+  - slash command
+  - copywriting
+updatedAt: 2026-07-21
+---
+
+You have the idea in a few messy bullets. The gap is the drafting: the hook, the flow, the close. This command takes your rough notes and returns a LinkedIn post that keeps your specifics, opens with a line worth stopping for, and ends by asking for something. It drafts; you still make the final call on what to ship.
+
+## The command
+
+Save this as `.claude/commands/linkedin.md` in your project.
+
+```markdown
+---
+description: Draft a LinkedIn post from rough notes, with a hook and CTA.
+argument-hint: [paste your rough bullet notes]
+---
+
+You are a ghostwriter drafting a LinkedIn post from an operator's rough notes.
+The notes are: $ARGUMENTS
+
+Write one LinkedIn post. Rules:
+
+- First line is a hook that earns the "see more" click. No "I'm excited to
+  announce". Lead with tension, a number, or a specific claim.
+- 120 to 220 words. Short lines and line breaks, easy to scan on mobile.
+- Keep every specific detail from the notes (names, numbers, moments). Do not
+  smooth them into vague generalities.
+- One clear idea, not three. Cut anything that does not serve the hook.
+- End with a call to action that fits the post: a question, an invitation to
+  share an experience, or a link prompt.
+- No hashtag spam. Suggest at most 3 relevant hashtags on their own line.
+
+Then give me one alternate first line, so I can pick the stronger hook.
+```
+
+## How to use
+
+1. Save the block above as `.claude/commands/linkedin.md`.
+2. Run `/linkedin` and paste your bullet notes after it.
+3. Compare the two hook options and pick the one that creates the most tension.
+4. Edit the draft so it sounds like you, then post. Real detail beats polish.

--- a/src/content/library/social/weekly-social-plan.mdx
+++ b/src/content/library/social/weekly-social-plan.mdx
@@ -1,0 +1,74 @@
+---
+name: Weekly Social Plan
+category: social
+type: command
+tagline: Turn your content pillars into a 7 day social plan with hooks and CTAs.
+description: "A /social-plan slash command that builds a 7 day posting plan from your content pillars: one post per day with channel, hook, format, and CTA, so a week of social goes from blank to bookable in one pass."
+access: free
+related:
+  - linkedin-post-from-notes
+  - repurpose-blog-to-social
+  - content-calendar-scaffold
+author: alice-marketer
+tags:
+  - social
+  - content pillars
+  - slash command
+updatedAt: 2026-07-21
+publishedAt: 2026-07-21
+metaDescription: "Build a 7 day social media plan from your content pillars with Claude Code. One post per day: channel, hook, format, and CTA, ready to schedule."
+faq:
+  - q: How is this different from a content calendar?
+    a: "This plans one specific week at the post level: exact hook, format, and CTA per day. A calendar scaffolds themes and slots across a quarter. Use the calendar to decide what a week is about, then run this to fill it."
+  - q: Can I run it for more than one channel?
+    a: "Yes. Name every channel in the brief (for example LinkedIn plus Instagram) and the command assigns each day a channel and tailors the hook and format to it, rather than reposting one message everywhere."
+  - q: Does it write the full posts?
+    a: "No, and that is intentional. It gives you the angle, hook line, and CTA per day so you approve the plan fast. Expand any single day into a full post with the LinkedIn Post From Notes command when it is up next."
+---
+
+A week of social usually dies as a vague intention to "post more." This command turns your content pillars into a concrete 7 day plan: one post per day, each with a channel, a hook line, a format, and a call to action. You approve or swap at the plan level in two minutes, then hand each day to a drafting step. No blank calendar, no Monday scramble.
+
+## The command
+
+Save this as `.claude/commands/social-plan.md` in your project.
+
+```markdown
+---
+description: Build a 7 day social content plan from content pillars.
+argument-hint: [pillars, channels, audience, and the week's goal]
+---
+
+You are a social media strategist. The brief is: $ARGUMENTS
+
+If the content pillars, channels, audience, or the goal for this week are
+missing, ask for them first. Then build a 7 day plan as a table, one row per
+day (Monday to Sunday).
+
+Columns: Day, Channel, Pillar, Format, Hook, CTA.
+
+Rules:
+- Assign each day exactly one pillar. Spread the pillars across the week so no
+  pillar runs two days in a row.
+- Match the format to the channel and pillar (for example: carousel, short
+  video, text post, poll, single image, thread). Vary formats across the week.
+- Write the Hook as a real opening line a reader would stop on, not a topic
+  label. Make it specific to the audience.
+- Give each day one clear CTA (comment, save, click, sign up, DM). Do not put
+  the same CTA on every day.
+- Keep one lighter or community day in the week so it does not read as seven
+  sales posts.
+
+After the table:
+- List 2 backup posts that fit any pillar, for a day that falls through.
+- Note the single best-performing day to boost if there is budget, and why.
+
+Keep it realistic for one person to ship in a week.
+```
+
+## How to use
+
+1. Save the block above as `.claude/commands/social-plan.md`.
+2. Run `/social-plan` and give it your pillars, channels, audience, and this week's goal.
+3. Skim the Hook column first: if a hook is dull, ask for three alternates on that row.
+4. Copy the table into your scheduler and set the dates.
+5. Expand any single day into a finished post with the LinkedIn Post From Notes command.

--- a/src/data/library-categories.ts
+++ b/src/data/library-categories.ts
@@ -1,0 +1,103 @@
+/**
+ * Marketing Library category tree. Single source of truth for the hub cards,
+ * the category sidebar, and the sitemap. Order here is the display order.
+ * `blurb` is a one sentence card description. `intro` is the longer, keyword
+ * targeted paragraph shown at the top of each category page.
+ */
+
+export type LibraryCategorySlug =
+  | 'seo'
+  | 'content'
+  | 'paid-ads'
+  | 'analytics'
+  | 'email'
+  | 'social'
+  | 'reporting'
+  | 'competitive'
+  | 'project-ops';
+
+export interface LibraryCategory {
+  slug: LibraryCategorySlug;
+  label: string;
+  blurb: string;
+  intro: string;
+}
+
+export const LIBRARY_CATEGORIES: LibraryCategory[] = [
+  {
+    slug: 'seo',
+    label: 'SEO',
+    blurb: 'Keyword research, content briefs, and SERP intent prompts that help your pages rank.',
+    intro:
+      'The SEO section collects prompts and slash commands for the parts of search work that repeat every week: keyword research, search intent classification, content briefs, and title and meta description writing. Each entry is a real, copyable artifact you paste into Claude Code and run against your own keywords, so you skip the blank page and start from a structured draft. Marketers use these to build content briefs that developers and writers can follow, to sort a raw keyword list by informational, commercial, transactional, or navigational intent, and to produce SERP length checked titles and descriptions that fit Google without truncation. Every prompt here is free and ungated. Read the artifact, copy it into your project, and adapt the variables to your niche. If you run SEO for a site or a set of clients, these are the pieces you would otherwise rewrite by hand each time a new keyword lands on your plate.',
+  },
+  {
+    slug: 'content',
+    label: 'Content & Copy',
+    blurb: 'Copywriting workflows that turn one idea into outlines, drafts, and on brand copy.',
+    intro:
+      'The Content and Copy section holds workflows for turning a single idea into finished marketing writing: blog outlines, brand voice rules that persist across a project, and repurposing that spins one post into social ready copy. Each entry is a real prompt or command you can drop into Claude Code and run today. Marketers reach for these to draft an H2 and H3 outline from a target keyword, to enforce a consistent tone across everything an AI writes for a brand, and to turn one long form post into a LinkedIn post, an X thread, and an Instagram carousel without starting from scratch. The point is not to hand your voice to a machine. The point is to remove the mechanical parts, outlining, reformatting, first drafts, so the judgment work gets your attention. Everything here is free and copyable. Take the artifact, wire in your own brand details, and reuse it on every piece you ship.',
+  },
+  {
+    slug: 'paid-ads',
+    label: 'Ads & Paid',
+    blurb: 'Ad copy helpers that spin up headline and primary text variants fast.',
+    intro:
+      'The Ads and Paid section is for the copy side of paid media: headline variants, primary text options, and the angle testing that feeds a healthy ad account. Each entry is a real command you paste into Claude Code and run against one offer. Marketers use these to generate ten distinct headline and primary text variants in a single pass, each tagged with the angle it plays (pain, proof, curiosity, urgency, and so on), so a test has real variety instead of ten rewordings of the same line. Good paid performance comes from volume of distinct angles, and writing that volume by hand burns hours. These artifacts get you a labeled batch you can drop straight into your ad platform and start testing. Everything here is free and ungated. Copy the command, swap in your product, audience, and offer, and keep it as a repeatable step in your campaign launch checklist.',
+  },
+  {
+    slug: 'analytics',
+    label: 'Analytics & Data',
+    blurb: 'Prompts that translate plain English questions into GA4 steps and clear answers.',
+    intro:
+      'The Analytics and Data section turns the gap between a question and a report into something you can cross in one prompt. Each entry is a real artifact for Claude Code that takes a plain English analytics question and returns the exact steps to answer it. Marketers use these to translate a question like which channels drove the most signups last month into a concrete GA4 exploration: the dimensions to pick, the metrics to add, the filters to set, and the segment to compare against. Instead of guessing which report holds the answer, you get a build sheet you can follow inside GA4. This matters most for teams without a dedicated analyst, where the person asking the question is also the person who has to find it. Everything here is free and copyable. Paste the prompt, describe the question in your own words, and get the steps that lead to the number.',
+  },
+  {
+    slug: 'email',
+    label: 'Email & Lifecycle',
+    blurb: 'Commands that draft newsletters, subject lines, and lifecycle copy from a source.',
+    intro:
+      'The Email and Lifecycle section covers the drafting work behind newsletters and lifecycle messages: turning a source into a section, writing subject lines, and shaping a clear call to action. Each entry is a real command you run inside Claude Code. Marketers use these to summarize a link or article into a newsletter section that keeps your voice, complete with a subject line and a single CTA, so a weekly send stops eating an afternoon. The artifacts assume you still make the editorial calls, what to feature, what to cut, and handle the mechanical part of shaping raw material into a section that reads well. Everything in this section is free and ungated. Copy the command, point it at the URL or notes you are working from, and get a draft you can edit down rather than a blank compose window. Keep the command in your project and it becomes a fixed step in your newsletter routine.',
+  },
+  {
+    slug: 'social',
+    label: 'Social & Community',
+    blurb: 'Prompts that draft posts, threads, and captions from rough notes.',
+    intro:
+      'The Social and Community section is for turning rough thinking into posts worth publishing. Each entry is a real command or prompt for Claude Code that takes bullet notes or a raw idea and returns a drafted post with a hook and a call to action. Marketers use these to draft a LinkedIn post from a few messy lines, keeping the specifics that make a post credible while adding an opening that earns the click and a close that asks for something. The aim is to shorten the distance between having a thought and shipping it, without flattening your voice into generic social filler. These work best when you feed them real detail: a number, a moment, a specific opinion. Everything here is free and copyable. Paste the command, drop in your notes, and edit the draft to sound like you. Save it in your project so posting becomes a habit instead of a chore you avoid.',
+  },
+  {
+    slug: 'reporting',
+    label: 'Reporting & Dashboards',
+    blurb: 'Commands that turn raw metrics into weekly readouts and stakeholder summaries.',
+    intro:
+      'The Reporting and Dashboards section handles the translation from numbers to narrative. Each entry is a real prompt for Claude Code that takes a metrics export and returns a plain language readout: what moved, by how much, and what is worth a second look. Marketers use these to turn a weekly metrics CSV into a summary a stakeholder can read in a minute, with the week over week deltas called out and the noteworthy changes flagged instead of buried in a grid of numbers. The artifacts do the reading and framing so you spend your time on the decisions the numbers point to, not on assembling the recap. This is the unglamorous work that eats Monday mornings, and it is exactly the kind of pattern an AI handles well once you give it the structure. Everything here is free and ungated. Copy the prompt, paste your metrics, and get a readout you can send with light edits.',
+  },
+  {
+    slug: 'competitive',
+    label: 'Competitive Research',
+    blurb: 'Prompts that tear down rival pages, offers, and positioning.',
+    intro:
+      'The Competitive Research section is for looking hard at what other companies ship. Each entry is a real prompt for Claude Code that takes one competitor page and returns a structured teardown: their positioning, the offer, the proof they lean on, the calls to action, and the gaps you could exploit. Marketers use these to analyze a rival landing page without staring at it for an hour, getting a consistent breakdown they can compare across several competitors. The output gives you a repeatable lens, so five teardowns line up on the same dimensions instead of drifting into five different write ups. This is research that informs your own positioning, messaging tests, and offer design. Everything in this section is free and copyable. Paste the prompt, drop in the page content or URL, and get a teardown you can act on. Run it across a set of competitors and patterns start to show, which is where the real strategy work begins.',
+  },
+  {
+    slug: 'project-ops',
+    label: 'Project & Ops',
+    blurb: 'Commands that scaffold calendars, briefs, and repeatable marketing systems.',
+    intro:
+      'The Project and Ops section covers the scaffolding that keeps marketing work organized: content calendars, briefs, and the repeatable structures a team runs on. Each entry is a real command for Claude Code that builds one of these from a short description. Marketers use these to scaffold a ninety day rolling content calendar, with themes, cadence, and slots laid out, so planning starts from a real structure instead of an empty spreadsheet. The artifacts handle the setup, the parts that are the same every quarter, so you spend your time on the choices that actually differ. This is operations work: not glamorous, but the difference between a plan that ships and a plan that stays in someone head. Everything here is free and ungated. Copy the command, describe your situation, cadence, channels, goals, and get a scaffold you can fill in and run. Keep it in your project and reuse it every planning cycle.',
+  },
+];
+
+export function getCategory(slug: string): LibraryCategory | undefined {
+  return LIBRARY_CATEGORIES.find((c) => c.slug === slug);
+}
+
+/** Human label for an entry type badge. */
+export const TYPE_LABELS: Record<string, string> = {
+  prompt: 'Prompt',
+  command: 'Slash Command',
+  subagent: 'Subagent',
+  mcp: 'MCP Server',
+  skill: 'Skill',
+};

--- a/src/lib/library.ts
+++ b/src/lib/library.ts
@@ -27,6 +27,25 @@ export function typeLabel(type: string): string {
 }
 
 /**
+ * SERP-safe meta description for an entry. Prefers the hand-written
+ * `metaDescription`, otherwise trims the long on-page `description` to a clean
+ * word boundary under 155 chars (the on-page paragraph keeps the full text).
+ */
+export function metaFor(data: LibraryEntry['data']): string {
+  if (data.metaDescription) return data.metaDescription;
+  return truncateAtWord(data.description, 155);
+}
+
+/** Cuts text to <= max chars at the last word boundary, no trailing punctuation. */
+export function truncateAtWord(text: string, max: number): string {
+  const clean = text.trim();
+  if (clean.length <= max) return clean;
+  const slice = clean.slice(0, max);
+  const cut = slice.slice(0, slice.lastIndexOf(' '));
+  return cut.replace(/[\s,.;:]+$/, '');
+}
+
+/**
  * Resolve the related entries for a card row. Prefer the hand-picked `related`
  * slugs (matched by file slug), then fill from same-category siblings. Returns
  * 3 to 5 entries, never the entry itself.
@@ -77,34 +96,21 @@ export interface FaqPair {
 }
 
 /**
- * Standard question and answer pairs derived from entry metadata. Kept in code
- * (not frontmatter) so every entry emits a consistent, valid FAQPage without an
- * extra schema field. Real, useful answers, not filler.
+ * Q&A pairs for an entry. One generic, code-derived question always leads (so
+ * every entry emits a valid FAQPage), then any entry-specific `faq` pairs from
+ * frontmatter follow. The visible <details> and the FAQPage JSON-LD read from
+ * this same array, so they stay identical (Google's visible-match requirement).
  */
 export function buildEntryFaq(entry: LibraryEntry): FaqPair[] {
-  const { name, access } = entry.data;
+  const { name, access, faq } = entry.data;
   const kind = typeLabel(entry.data.type).toLowerCase();
-  const priceLine =
-    access === 'free'
-      ? `Yes. ${name} is a free entry in the marketing library. Copy the ${kind} and use it in your own projects at no cost.`
-      : `${name} is a paid entry. The free artifacts in the library stay free to copy; paid packs add extended versions.`;
+  const generic: FaqPair = {
+    q: `Is ${name} free to use in Claude Code?`,
+    a:
+      access === 'free'
+        ? `Yes. ${name} is a free entry in the marketing library. Copy the ${kind} and use it in Claude Code at no cost.`
+        : `${name} is a paid entry. The free artifacts in the library stay free to copy; paid packs add extended versions.`,
+  };
 
-  return [
-    {
-      q: `Is ${name} free to use?`,
-      a: priceLine,
-    },
-    {
-      q: `What does ${name} do?`,
-      a: entry.data.description,
-    },
-    {
-      q: `How do I use ${name} in Claude Code?`,
-      a: `Copy the ${kind} from the block above, paste it into Claude Code (as a message, or save it in your project as a slash command or memory file), then swap the placeholders for your own details and run it.`,
-    },
-    {
-      q: `Do I need to know how to code to use ${name}?`,
-      a: `No. ${name} is written for marketers. If you can copy text into Claude Code and edit a few placeholders, you can run it. No programming required.`,
-    },
-  ];
+  return [generic, ...(faq ?? [])];
 }

--- a/src/lib/library.ts
+++ b/src/lib/library.ts
@@ -1,0 +1,110 @@
+import type { CollectionEntry } from 'astro:content';
+import { TYPE_LABELS } from '../data/library-categories';
+
+export type LibraryEntry = CollectionEntry<'library'>;
+
+const AUTHOR_NAMES: Record<string, string> = {
+  'tri-vo': 'Tri Vo',
+  'alice-marketer': 'Alice Marketer',
+};
+
+/** The filename slug for an entry, e.g. `seo/content-brief-generator` -> `content-brief-generator`. */
+export function fileSlug(entry: LibraryEntry): string {
+  return entry.id.split('/').pop() ?? entry.id;
+}
+
+/** Public URL for an entry, driven by frontmatter category + file slug. */
+export function entryUrl(entry: LibraryEntry): string {
+  return `/library/${entry.data.category}/${fileSlug(entry)}/`;
+}
+
+export function authorName(slug: string): string {
+  return AUTHOR_NAMES[slug] ?? slug;
+}
+
+export function typeLabel(type: string): string {
+  return TYPE_LABELS[type] ?? type;
+}
+
+/**
+ * Resolve the related entries for a card row. Prefer the hand-picked `related`
+ * slugs (matched by file slug), then fill from same-category siblings. Returns
+ * 3 to 5 entries, never the entry itself.
+ */
+export function resolveRelated(entry: LibraryEntry, all: LibraryEntry[]): LibraryEntry[] {
+  const self = fileSlug(entry);
+  const bySlug = new Map(all.map((e) => [fileSlug(e), e]));
+  const picked: LibraryEntry[] = [];
+  const seen = new Set<string>([self]);
+
+  for (const slug of entry.data.related) {
+    const match = bySlug.get(slug);
+    if (match && !seen.has(slug)) {
+      picked.push(match);
+      seen.add(slug);
+    }
+  }
+
+  if (picked.length < 3) {
+    for (const e of all) {
+      if (picked.length >= 5) break;
+      const slug = fileSlug(e);
+      if (seen.has(slug)) continue;
+      if (e.data.category === entry.data.category) {
+        picked.push(e);
+        seen.add(slug);
+      }
+    }
+  }
+
+  // Last resort: any other entries, so the row is never empty on a lone category.
+  if (picked.length < 3) {
+    for (const e of all) {
+      if (picked.length >= 5) break;
+      const slug = fileSlug(e);
+      if (seen.has(slug)) continue;
+      picked.push(e);
+      seen.add(slug);
+    }
+  }
+
+  return picked.slice(0, 5);
+}
+
+export interface FaqPair {
+  q: string;
+  a: string;
+}
+
+/**
+ * Standard question and answer pairs derived from entry metadata. Kept in code
+ * (not frontmatter) so every entry emits a consistent, valid FAQPage without an
+ * extra schema field. Real, useful answers, not filler.
+ */
+export function buildEntryFaq(entry: LibraryEntry): FaqPair[] {
+  const { name, access } = entry.data;
+  const kind = typeLabel(entry.data.type).toLowerCase();
+  const priceLine =
+    access === 'free'
+      ? `Yes. ${name} is a free entry in the marketing library. Copy the ${kind} and use it in your own projects at no cost.`
+      : `${name} is a paid entry. The free artifacts in the library stay free to copy; paid packs add extended versions.`;
+
+  return [
+    {
+      q: `Is ${name} free to use?`,
+      a: priceLine,
+    },
+    {
+      q: `What does ${name} do?`,
+      a: entry.data.description,
+    },
+    {
+      q: `How do I use ${name} in Claude Code?`,
+      a: `Copy the ${kind} from the block above, paste it into Claude Code (as a message, or save it in your project as a slash command or memory file), then swap the placeholders for your own details and run it.`,
+    },
+    {
+      q: `Do I need to know how to code to use ${name}?`,
+      a: `No. ${name} is written for marketers. If you can copy text into Claude Code and edit a few placeholders, you can run it. No programming required.`,
+    },
+  ];
+}

--- a/src/lib/og/build.ts
+++ b/src/lib/og/build.ts
@@ -18,8 +18,10 @@ import { html as satoriHtml } from 'satori-html';
 import { Resvg } from '@resvg/resvg-js';
 import { renderModuleLessonTemplate } from './templates/module-lesson';
 import { renderGenericTemplate, type GenericTemplateInput } from './templates/generic';
+import { renderLibraryTemplate } from './templates/library';
 import { OG_DIMENSIONS, OG_TEMPLATE_VERSION } from './config';
 import { injectPngText } from './png-metadata';
+import { LIBRARY_CATEGORIES, TYPE_LABELS } from '../../data/library-categories';
 
 const BUILD_STAMP = {
   'engine-version': String(OG_TEMPLATE_VERSION),
@@ -31,6 +33,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '../../..');
 const OUT_DIR = join(ROOT, 'public/og');
 const MODULES_DIR = join(ROOT, 'src/content/modules');
+const LIBRARY_DIR = join(ROOT, 'src/content/library');
 
 const FONTS_DIR = join(__dirname, 'fonts');
 const fonts = [
@@ -123,6 +126,45 @@ function urlSlugForLesson(filePath: string, fm: ModuleFrontmatter): string {
   return `${fm.module}-${kebab}`;
 }
 
+interface LibraryFrontmatter {
+  name: string;
+  category: string;
+  type: string;
+  tagline?: string;
+}
+
+/** Reads name/category/type/tagline from a library entry's frontmatter block. */
+function parseLibraryFrontmatter(source: string): LibraryFrontmatter {
+  const match = source.match(/^---\n([\s\S]+?)\n---/);
+  if (!match) throw new Error('No frontmatter block');
+  const data: Record<string, string> = {};
+  for (const line of match[1].split('\n')) {
+    const m = line.match(/^(\w+):\s*(.+)$/);
+    if (!m) continue;
+    data[m[1]] = m[2].trim().replace(/^['"]|['"]$/g, '');
+  }
+  return {
+    name: String(data.name),
+    category: String(data.category),
+    type: String(data.type),
+    tagline: data.tagline ? String(data.tagline) : undefined,
+  };
+}
+
+/** Walks src/content/library/ recursively and returns all MDX files. */
+function listLibraryFiles(): string[] {
+  const out: string[] = [];
+  function walk(dir: string) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile() && entry.name.endsWith('.mdx')) out.push(full);
+    }
+  }
+  walk(LIBRARY_DIR);
+  return out;
+}
+
 const STATIC_PAGES: Record<
   string,
   Omit<GenericTemplateInput, never> & { badge: string }
@@ -175,6 +217,7 @@ async function main(): Promise<void> {
   const startedAt = Date.now();
   mkdirSync(join(OUT_DIR, 'pages'), { recursive: true });
   mkdirSync(join(OUT_DIR, 'modules'), { recursive: true });
+  mkdirSync(join(OUT_DIR, 'library'), { recursive: true });
 
   let total = 0;
   let totalBytes = 0;
@@ -209,6 +252,25 @@ async function main(): Promise<void> {
     total += 1;
     totalBytes += png.byteLength;
     console.log(`✓ modules/${slug}.png (${(png.byteLength / 1024).toFixed(0)} KB)`);
+  }
+
+  // --- Marketing Library entries ---
+  const categoryLabels = new Map(LIBRARY_CATEGORIES.map((c) => [c.slug, c.label]));
+  for (const file of listLibraryFiles()) {
+    const fm = parseLibraryFrontmatter(readFileSync(file, 'utf8'));
+    const slug = file.split('/').at(-1)!.replace(/\.mdx$/, '');
+    const html = renderLibraryTemplate({
+      name: fm.name,
+      categoryLabel: categoryLabels.get(fm.category) ?? fm.category,
+      typeLabel: TYPE_LABELS[fm.type] ?? fm.type,
+      tagline: fm.tagline,
+    });
+    const png = await renderToPng(html);
+    const key = `${fm.category}-${slug}`;
+    writeFileSync(join(OUT_DIR, 'library', `${key}.png`), png);
+    total += 1;
+    totalBytes += png.byteLength;
+    console.log(`✓ library/${key}.png (${(png.byteLength / 1024).toFixed(0)} KB)`);
   }
 
   const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);

--- a/src/lib/og/templates/library.ts
+++ b/src/lib/og/templates/library.ts
@@ -1,0 +1,74 @@
+import { OG_COLORS, OG_SITE } from '../config';
+
+export interface LibraryTemplateInput {
+  /** Entry name, e.g. "GA4 Question Answerer" */
+  name: string;
+  /** Category label, e.g. "Analytics & Data" */
+  categoryLabel: string;
+  /** Type label, e.g. "Slash Command" */
+  typeLabel: string;
+  /** One-line tagline shown under the name */
+  tagline?: string;
+}
+
+function sanitize(text: string): string {
+  return text
+    .replace(/&amp;/g, 'and')
+    .replace(/&lt;/g, '')
+    .replace(/&gt;/g, '')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/[<>]/g, '')
+    .replace(/&(?!#?\w+;)/g, 'and')
+    .replace(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}\u{1F000}-\u{1F02F}\u{FE0F}]/gu, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function titleFontSize(title: string): number {
+  if (title.length <= 24) return 92;
+  if (title.length <= 40) return 76;
+  if (title.length <= 60) return 60;
+  return 48;
+}
+
+/**
+ * Marketing Library entry OG template. Rust background to distinguish it from
+ * the plum course lessons, cream name, mustard category pill, olive type pill.
+ */
+export function renderLibraryTemplate(input: LibraryTemplateInput): string {
+  const name = sanitize(input.name);
+  const category = sanitize(input.categoryLabel);
+  const type = sanitize(input.typeLabel);
+  const tagline = input.tagline ? sanitize(input.tagline) : '';
+  const fontSize = titleFontSize(name);
+
+  return `
+    <div style="display:flex;flex-direction:column;justify-content:space-between;width:100%;height:100%;background:${OG_COLORS.rust};padding:64px 80px;box-sizing:border-box;border:6px solid ${OG_COLORS.charcoal};">
+      <div style="display:flex;justify-content:space-between;align-items:center;width:100%;">
+        <div style="display:flex;background:${OG_COLORS.cream};color:${OG_COLORS.charcoal};padding:10px 22px;font-family:Outfit;font-weight:700;font-size:24px;">${OG_SITE.name}</div>
+        <div style="display:flex;background:${OG_COLORS.mustard};color:${OG_COLORS.charcoal};padding:10px 22px;font-family:Outfit;font-weight:700;font-size:20px;letter-spacing:2px;border:3px solid ${OG_COLORS.charcoal};">${category}</div>
+      </div>
+      <div style="display:flex;flex-direction:column;max-width:1040px;">
+        <div style="display:flex;font-family:Righteous;font-size:${fontSize}px;color:${OG_COLORS.cream};line-height:1.05;">${name}</div>
+        ${
+          tagline
+            ? `<div style="display:flex;font-family:Outfit;font-weight:400;font-size:26px;color:${OG_COLORS.cream};opacity:0.9;margin-top:24px;max-width:900px;line-height:1.4;">${tagline}</div>`
+            : ''
+        }
+      </div>
+      <div style="display:flex;justify-content:space-between;align-items:flex-end;width:100%;">
+        <div style="display:flex;align-items:center;">
+          <div style="display:flex;background:${OG_COLORS.olive};color:${OG_COLORS.cream};padding:8px 18px;font-family:Outfit;font-weight:700;font-size:18px;margin-right:12px;">${type}</div>
+          <div style="display:flex;font-family:Outfit;font-weight:400;font-size:18px;color:${OG_COLORS.cream};opacity:0.7;letter-spacing:1px;">MARKETING LIBRARY</div>
+        </div>
+        <div style="display:flex;align-items:center;">
+          <div style="display:flex;width:18px;height:18px;background:${OG_COLORS.cream};margin-right:10px;"></div>
+          <div style="display:flex;width:18px;height:18px;background:${OG_COLORS.mustard};margin-right:10px;"></div>
+          <div style="display:flex;width:18px;height:18px;background:${OG_COLORS.plum};"></div>
+        </div>
+      </div>
+    </div>
+  `;
+}

--- a/src/lib/og/url.ts
+++ b/src/lib/og/url.ts
@@ -66,6 +66,15 @@ export async function resolveOgImage(
     return `/og/modules/${module}-${slug}.png`;
   }
 
+  // Library entry pages: /library/{category}/{slug}/ → build-time OG asset.
+  // Two path segments required, so the hub and category index pages fall
+  // through to the default cover.
+  const libraryMatch = ctx.path.match(/^\/library\/([^/]+)\/([^/]+)\/?$/);
+  if (libraryMatch) {
+    const [, category, slug] = libraryMatch;
+    return `/og/library/${category}-${slug}.png`;
+  }
+
   return STATIC_FALLBACK_DEFAULT;
 }
 

--- a/src/pages/library/[category]/[entry].astro
+++ b/src/pages/library/[category]/[entry].astro
@@ -14,6 +14,7 @@ import {
   typeLabel,
   resolveRelated,
   buildEntryFaq,
+  metaFor,
 } from '../../../lib/library';
 
 export async function getStaticPaths() {
@@ -63,6 +64,13 @@ const softwareSchema = {
   codeSampleType: 'full solution',
   programmingLanguage: 'Claude Code',
   isAccessibleForFree: data.access === 'free',
+  license: 'https://opensource.org/licenses/MIT',
+  isPartOf: {
+    '@type': 'CollectionPage',
+    name: 'Claude Code Marketing Library',
+    url: `${siteUrl}/library/`,
+  },
+  ...(data.publishedAt && { datePublished: data.publishedAt.toISOString().slice(0, 10) }),
   ...(data.updatedAt && { dateModified: data.updatedAt.toISOString().slice(0, 10) }),
 };
 
@@ -78,8 +86,8 @@ const faqSchema = {
 ---
 
 <BaseLayout
-  title={`${data.name} — ${category.label} | Claude Code Marketing Library`}
-  description={data.description}
+  title={`${data.name}, ${category.label}`}
+  description={metaFor(data)}
   keywords={data.tags.length ? data.tags : [category.label, 'Claude Code', 'marketing']}
   type="article"
   author={author}

--- a/src/pages/library/[category]/[entry].astro
+++ b/src/pages/library/[category]/[entry].astro
@@ -1,0 +1,308 @@
+---
+export const prerender = true;
+
+import { getCollection, render } from 'astro:content';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import Header from '../../../components/Header.astro';
+import Footer from '../../../components/Footer.astro';
+import CategorySidebar from '../../../components/library/category-sidebar.astro';
+import EntryCard from '../../../components/library/entry-card.astro';
+import { LIBRARY_CATEGORIES, getCategory } from '../../../data/library-categories';
+import {
+  fileSlug,
+  authorName,
+  typeLabel,
+  resolveRelated,
+  buildEntryFaq,
+} from '../../../lib/library';
+
+export async function getStaticPaths() {
+  const entries = await getCollection('library');
+  return entries.map((entry) => ({
+    params: { category: entry.data.category, entry: fileSlug(entry) },
+    props: { entry, all: entries },
+  }));
+}
+
+const { entry, all } = Astro.props;
+const { data } = entry;
+const category = getCategory(data.category)!;
+const slug = fileSlug(entry);
+
+const counts: Record<string, number> = {};
+for (const cat of LIBRARY_CATEGORIES) counts[cat.slug] = 0;
+for (const e of all) counts[e.data.category] = (counts[e.data.category] ?? 0) + 1;
+
+const related = resolveRelated(entry, all);
+const faq = buildEntryFaq(entry);
+const { Content } = await render(entry);
+
+const siteUrl = 'https://cc4.marketing';
+const pageUrl = `${siteUrl}/library/${data.category}/${slug}/`;
+const author = authorName(data.author);
+
+const breadcrumb = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: `${siteUrl}/` },
+    { '@type': 'ListItem', position: 2, name: 'Library', item: `${siteUrl}/library/` },
+    { '@type': 'ListItem', position: 3, name: category.label, item: `${siteUrl}/library/${data.category}/` },
+    { '@type': 'ListItem', position: 4, name: data.name, item: pageUrl },
+  ],
+};
+
+const softwareSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareSourceCode',
+  name: data.name,
+  description: data.description,
+  url: pageUrl,
+  author: { '@type': 'Person', name: author },
+  keywords: data.tags.join(', '),
+  codeSampleType: 'full solution',
+  programmingLanguage: 'Claude Code',
+  isAccessibleForFree: data.access === 'free',
+  ...(data.updatedAt && { dateModified: data.updatedAt.toISOString().slice(0, 10) }),
+};
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faq.map((pair) => ({
+    '@type': 'Question',
+    name: pair.q,
+    acceptedAnswer: { '@type': 'Answer', text: pair.a },
+  })),
+};
+---
+
+<BaseLayout
+  title={`${data.name} — ${category.label} | Claude Code Marketing Library`}
+  description={data.description}
+  keywords={data.tags.length ? data.tags : [category.label, 'Claude Code', 'marketing']}
+  type="article"
+  author={author}
+  modifiedDate={data.updatedAt?.toISOString()}
+  showCourseSchema={false}
+  showBreadcrumb={false}
+>
+  <Header />
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumb)} />
+  <script type="application/ld+json" set:html={JSON.stringify(softwareSchema)} />
+  <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
+
+  <main class="lib-entry">
+    <nav class="lib-breadcrumb" aria-label="Breadcrumb">
+      <a href="/">Home</a>
+      <span>/</span>
+      <a href="/library/">Library</a>
+      <span>/</span>
+      <a href={`/library/${data.category}/`}>{category.label}</a>
+      <span>/</span>
+      <span aria-current="page">{data.name}</span>
+    </nav>
+
+    <div class="lib-entry-layout">
+      <aside class="lib-entry-aside">
+        <CategorySidebar active={data.category} counts={counts} />
+      </aside>
+
+      <article class="lib-entry-main">
+        <div class="lib-entry-badges">
+          <span class="lib-badge lib-badge-type">{typeLabel(data.type)}</span>
+          <span class={`lib-badge lib-badge-${data.access}`}>{data.access === 'free' ? 'Free' : 'Paid'}</span>
+        </div>
+        <h1 class="lib-entry-name">{data.name}</h1>
+        <p class="lib-entry-tagline">{data.tagline}</p>
+        <p class="lib-entry-desc">{data.description}</p>
+        <p class="lib-entry-by">By {author}</p>
+
+        <div class="prose">
+          <Content />
+        </div>
+
+        <section class="lib-faq" aria-labelledby="lib-faq-title">
+          <h2 id="lib-faq-title">Questions and answers</h2>
+          {faq.map((pair) => (
+            <details class="lib-faq-item">
+              <summary>{pair.q}</summary>
+              <p>{pair.a}</p>
+            </details>
+          ))}
+        </section>
+
+        {related.length > 0 && (
+          <section class="lib-related" aria-labelledby="lib-related-title">
+            <h2 id="lib-related-title">Related in the library</h2>
+            <div class="lib-related-grid">
+              {related.map((rel) => (
+                <EntryCard entry={rel} />
+              ))}
+            </div>
+          </section>
+        )}
+      </article>
+    </div>
+  </main>
+
+  <Footer />
+</BaseLayout>
+
+<style>
+  .lib-entry {
+    padding: 110px 24px 80px;
+    max-width: 1180px;
+    margin: 0 auto;
+  }
+
+  .lib-breadcrumb {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    font-size: 0.85em;
+    color: var(--text-secondary);
+    margin-bottom: 28px;
+    flex-wrap: wrap;
+  }
+
+  .lib-breadcrumb a { color: var(--rust); text-decoration: none; }
+  .lib-breadcrumb a:hover { text-decoration: underline; }
+
+  .lib-entry-layout {
+    display: grid;
+    grid-template-columns: 240px minmax(0, 1fr);
+    gap: 40px;
+    align-items: start;
+  }
+
+  .lib-entry-badges {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 14px;
+    flex-wrap: wrap;
+  }
+
+  .lib-badge {
+    font-size: 0.72em;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 3px 10px;
+    border: 1px solid var(--border-color);
+  }
+
+  .lib-badge-type { background: var(--plum); color: #fff; border-color: var(--plum); }
+  .lib-badge-free { background: var(--tint-rust-2); color: var(--rust); border-color: var(--rust); }
+  .lib-badge-paid { background: var(--mustard); color: var(--ink-on-mustard); border-color: var(--ink-on-mustard); }
+
+  .lib-entry-name {
+    font-family: var(--font-display);
+    font-size: 2.6em;
+    margin: 0 0 12px;
+    line-height: 1.1;
+    color: var(--text-primary);
+  }
+
+  .lib-entry-tagline {
+    font-size: 1.2em;
+    color: var(--text-primary);
+    margin: 0 0 8px;
+  }
+
+  .lib-entry-desc {
+    font-size: 1.02em;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    margin: 0 0 8px;
+  }
+
+  .lib-entry-by {
+    font-size: 0.85em;
+    font-weight: 600;
+    color: var(--rust);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin: 0 0 32px;
+  }
+
+  /* Prose (mirrors the lesson prose so MDX bodies render consistently). */
+  .prose { font-size: 1.05em; line-height: 1.8; }
+  .prose :global(h2) {
+    font-family: var(--font-display);
+    font-size: 1.6em;
+    margin: 40px 0 18px;
+    padding-top: 20px;
+    border-top: 2px solid var(--border-color);
+    color: var(--text-primary);
+  }
+  .prose :global(h3) {
+    font-family: var(--font-display);
+    font-size: 1.3em;
+    margin: 28px 0 14px;
+    color: var(--text-primary);
+  }
+  .prose :global(p) { margin-bottom: 18px; }
+  .prose :global(ul), .prose :global(ol) { margin: 0 0 20px 24px; }
+  .prose :global(li) { margin-bottom: 10px; }
+  .prose :global(code) {
+    background: var(--bg-primary);
+    padding: 2px 8px;
+    font-family: 'Fira Code', monospace;
+    font-size: 0.9em;
+    border: 1px solid var(--border-color);
+    color: var(--text-primary);
+  }
+  .prose :global(pre) {
+    background: var(--code-surface);
+    color: var(--code-ink);
+    padding: 24px;
+    overflow-x: auto;
+    margin: 24px 0;
+    border: 3px solid var(--border-color);
+  }
+  .prose :global(pre code) { background: none; border: none; padding: 0; color: inherit; }
+
+  .lib-faq { margin-top: 48px; }
+  .lib-faq h2, .lib-related h2 {
+    font-family: var(--font-display);
+    font-size: 1.6em;
+    color: var(--text-primary);
+    margin: 0 0 20px;
+  }
+
+  .lib-faq-item {
+    border: 2px solid var(--border-color);
+    background: var(--bg-secondary);
+    padding: 4px 18px;
+    margin-bottom: 12px;
+  }
+
+  .lib-faq-item summary {
+    cursor: pointer;
+    font-weight: 600;
+    padding: 14px 0;
+    color: var(--text-primary);
+    list-style-position: inside;
+  }
+
+  .lib-faq-item p {
+    color: var(--text-secondary);
+    line-height: 1.6;
+    padding: 0 0 16px;
+    margin: 0;
+  }
+
+  .lib-related { margin-top: 48px; }
+
+  .lib-related-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 24px;
+  }
+
+  @media (max-width: 860px) {
+    .lib-entry-layout { grid-template-columns: 1fr; gap: 28px; }
+    .lib-entry-aside { order: 2; }
+  }
+</style>

--- a/src/pages/library/[category]/index.astro
+++ b/src/pages/library/[category]/index.astro
@@ -8,6 +8,7 @@ import Footer from '../../../components/Footer.astro';
 import CategorySidebar from '../../../components/library/category-sidebar.astro';
 import EntryCard from '../../../components/library/entry-card.astro';
 import { LIBRARY_CATEGORIES } from '../../../data/library-categories';
+import { fileSlug } from '../../../lib/library';
 
 export async function getStaticPaths() {
   const entries = await getCollection('library');
@@ -41,10 +42,22 @@ const breadcrumb = {
     { '@type': 'ListItem', position: 3, name: category.label, item: catUrl },
   ],
 };
+
+const itemList = {
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  name: `${category.label}, Claude Code Marketing Library`,
+  itemListElement: entries.map((entry, i) => ({
+    '@type': 'ListItem',
+    position: i + 1,
+    name: entry.data.name,
+    url: `${siteUrl}/library/${entry.data.category}/${fileSlug(entry)}/`,
+  })),
+};
 ---
 
 <BaseLayout
-  title={`${category.label} — Claude Code Marketing Library`}
+  title={`${category.label}, Marketing Library`}
   description={category.blurb}
   keywords={[`${category.label} prompts`, 'Claude Code', 'marketing library', 'AI marketing']}
   showCourseSchema={false}
@@ -52,6 +65,9 @@ const breadcrumb = {
 >
   <Header />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumb)} />
+  {entries.length > 0 && (
+    <script type="application/ld+json" set:html={JSON.stringify(itemList)} />
+  )}
 
   <main class="lib-cat">
     <nav class="lib-breadcrumb" aria-label="Breadcrumb">

--- a/src/pages/library/[category]/index.astro
+++ b/src/pages/library/[category]/index.astro
@@ -1,0 +1,175 @@
+---
+export const prerender = true;
+
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import Header from '../../../components/Header.astro';
+import Footer from '../../../components/Footer.astro';
+import CategorySidebar from '../../../components/library/category-sidebar.astro';
+import EntryCard from '../../../components/library/entry-card.astro';
+import { LIBRARY_CATEGORIES } from '../../../data/library-categories';
+
+export async function getStaticPaths() {
+  const entries = await getCollection('library');
+  return LIBRARY_CATEGORIES.map((cat) => ({
+    params: { category: cat.slug },
+    props: {
+      category: cat,
+      entries: entries
+        .filter((e) => e.data.category === cat.slug)
+        .sort((a, b) => a.data.name.localeCompare(b.data.name)),
+    },
+  }));
+}
+
+const { category, entries } = Astro.props;
+
+const allEntries = await getCollection('library');
+const counts: Record<string, number> = {};
+for (const cat of LIBRARY_CATEGORIES) counts[cat.slug] = 0;
+for (const e of allEntries) counts[e.data.category] = (counts[e.data.category] ?? 0) + 1;
+
+const siteUrl = 'https://cc4.marketing';
+const catUrl = `${siteUrl}/library/${category.slug}/`;
+
+const breadcrumb = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: `${siteUrl}/` },
+    { '@type': 'ListItem', position: 2, name: 'Library', item: `${siteUrl}/library/` },
+    { '@type': 'ListItem', position: 3, name: category.label, item: catUrl },
+  ],
+};
+---
+
+<BaseLayout
+  title={`${category.label} — Claude Code Marketing Library`}
+  description={category.blurb}
+  keywords={[`${category.label} prompts`, 'Claude Code', 'marketing library', 'AI marketing']}
+  showCourseSchema={false}
+  showBreadcrumb={false}
+>
+  <Header />
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumb)} />
+
+  <main class="lib-cat">
+    <nav class="lib-breadcrumb" aria-label="Breadcrumb">
+      <a href="/">Home</a>
+      <span>/</span>
+      <a href="/library/">Library</a>
+      <span>/</span>
+      <span aria-current="page">{category.label}</span>
+    </nav>
+
+    <div class="lib-cat-layout">
+      <aside class="lib-cat-aside">
+        <CategorySidebar active={category.slug} counts={counts} />
+      </aside>
+
+      <div class="lib-cat-main">
+        <header class="lib-cat-head">
+          <h1>{category.label}</h1>
+          <p class="lib-cat-intro">{category.intro}</p>
+        </header>
+
+        {entries.length === 0 ? (
+          <div class="lib-cat-empty">
+            <h2>Entries coming soon</h2>
+            <p>
+              We are still writing the {category.label} artifacts. In the meantime, browse the
+              other categories or <a href="/download/">get new drops by email</a>.
+            </p>
+          </div>
+        ) : (
+          <div class="lib-cat-grid">
+            {entries.map((entry) => (
+              <EntryCard entry={entry} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  </main>
+
+  <Footer />
+</BaseLayout>
+
+<style>
+  .lib-cat {
+    padding: 110px 24px 80px;
+    max-width: 1180px;
+    margin: 0 auto;
+  }
+
+  .lib-breadcrumb {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    font-size: 0.85em;
+    color: var(--text-secondary);
+    margin-bottom: 28px;
+    flex-wrap: wrap;
+  }
+
+  .lib-breadcrumb a {
+    color: var(--rust);
+    text-decoration: none;
+  }
+
+  .lib-breadcrumb a:hover { text-decoration: underline; }
+
+  .lib-cat-layout {
+    display: grid;
+    grid-template-columns: 240px minmax(0, 1fr);
+    gap: 40px;
+    align-items: start;
+  }
+
+  .lib-cat-head {
+    margin-bottom: 32px;
+  }
+
+  .lib-cat-head h1 {
+    font-family: var(--font-display);
+    font-size: 2.6em;
+    margin: 0 0 16px;
+    color: var(--text-primary);
+  }
+
+  .lib-cat-intro {
+    font-size: 1.02em;
+    color: var(--text-secondary);
+    line-height: 1.7;
+    margin: 0;
+  }
+
+  .lib-cat-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 24px;
+  }
+
+  .lib-cat-empty {
+    border: 2px dashed var(--border-color);
+    padding: 48px 32px;
+    text-align: center;
+  }
+
+  .lib-cat-empty h2 {
+    font-family: var(--font-display);
+    font-size: 1.5em;
+    color: var(--rust);
+    margin: 0 0 12px;
+  }
+
+  .lib-cat-empty p {
+    color: var(--text-secondary);
+    margin: 0;
+  }
+
+  @media (max-width: 860px) {
+    .lib-cat-layout { grid-template-columns: 1fr; gap: 28px; }
+    .lib-cat-aside { order: 2; }
+  }
+</style>

--- a/src/pages/library/index.astro
+++ b/src/pages/library/index.astro
@@ -26,17 +26,30 @@ const breadcrumb = {
     { '@type': 'ListItem', position: 2, name: 'Library', item: 'https://cc4.marketing/library/' },
   ],
 };
+
+const itemList = {
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  name: 'Claude Code Marketing Library categories',
+  itemListElement: LIBRARY_CATEGORIES.map((cat, i) => ({
+    '@type': 'ListItem',
+    position: i + 1,
+    name: cat.label,
+    url: `https://cc4.marketing/library/${cat.slug}/`,
+  })),
+};
 ---
 
 <BaseLayout
-  title="Marketing Library — Claude Code Prompts & Commands"
-  description="A free, curated library of Claude Code prompts, slash commands, subagents, and skills for marketers. Copy real artifacts for SEO, content, ads, analytics, email, and more."
+  title="Marketing Library, Claude Code Prompts and Commands"
+  description="Free Claude Code prompts, slash commands, subagents, and skills for marketers. Copy real artifacts for SEO, content, ads, analytics, email, and more."
   keywords={['Claude Code prompts', 'marketing slash commands', 'AI marketing prompts', 'Claude Code for marketers', 'marketing prompt library']}
   showCourseSchema={false}
   showBreadcrumb={false}
 >
   <Header />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumb)} />
+  <script type="application/ld+json" set:html={JSON.stringify(itemList)} />
 
   <section class="lib-hero">
     <div class="lib-hero-inner">

--- a/src/pages/library/index.astro
+++ b/src/pages/library/index.astro
@@ -1,0 +1,204 @@
+---
+export const prerender = true;
+
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import { LIBRARY_CATEGORIES } from '../../data/library-categories';
+
+const entries = await getCollection('library');
+
+const counts: Record<string, number> = {};
+for (const cat of LIBRARY_CATEGORIES) counts[cat.slug] = 0;
+for (const entry of entries) {
+  counts[entry.data.category] = (counts[entry.data.category] ?? 0) + 1;
+}
+const total = entries.length;
+
+const REPO_URL = 'https://github.com/cc4-marketing/marketing-library';
+
+const breadcrumb = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://cc4.marketing/' },
+    { '@type': 'ListItem', position: 2, name: 'Library', item: 'https://cc4.marketing/library/' },
+  ],
+};
+---
+
+<BaseLayout
+  title="Marketing Library — Claude Code Prompts & Commands"
+  description="A free, curated library of Claude Code prompts, slash commands, subagents, and skills for marketers. Copy real artifacts for SEO, content, ads, analytics, email, and more."
+  keywords={['Claude Code prompts', 'marketing slash commands', 'AI marketing prompts', 'Claude Code for marketers', 'marketing prompt library']}
+  showCourseSchema={false}
+  showBreadcrumb={false}
+>
+  <Header />
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumb)} />
+
+  <section class="lib-hero">
+    <div class="lib-hero-inner">
+      <span class="lib-hero-label">Marketing Library</span>
+      <h1 class="lib-hero-title">Claude Code prompts and commands for marketers</h1>
+      <p class="lib-hero-desc">
+        A curated library of prompts, slash commands, subagents, and skills you can paste
+        straight into Claude Code. Every entry here is free and copyable, real artifacts for
+        real marketing work, no sign up wall between you and the code block.
+      </p>
+      <div class="lib-hero-cta">
+        <a href="/download/" class="btn btn-primary">Get new drops by email</a>
+        <a href={REPO_URL} class="btn btn-secondary" target="_blank" rel="noopener nofollow">
+          Master repo on GitHub
+        </a>
+      </div>
+      <p class="lib-hero-note">{total} free artifacts across 9 categories. More added regularly.</p>
+    </div>
+  </section>
+
+  <section class="lib-body">
+    <div class="lib-body-inner">
+      <div class="lib-cat-grid">
+        {LIBRARY_CATEGORIES.map((cat) => (
+          <a href={`/library/${cat.slug}/`} class="lib-cat-card">
+            <div class="lib-cat-count">{counts[cat.slug] ?? 0}</div>
+            <h2 class="lib-cat-name">{cat.label}</h2>
+            <p class="lib-cat-blurb">{cat.blurb}</p>
+            <span class="lib-cat-link">Browse {cat.label} →</span>
+          </a>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <Footer />
+</BaseLayout>
+
+<style>
+  .lib-hero {
+    position: relative;
+    padding: 140px 24px 60px;
+    text-align: center;
+    background: linear-gradient(135deg, var(--bg-primary) 0%, var(--tint-rust-1) 100%);
+  }
+
+  .lib-hero-inner {
+    max-width: 760px;
+    margin: 0 auto;
+  }
+
+  .lib-hero-label {
+    display: inline-block;
+    font-size: 0.75em;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    color: var(--rust);
+    background: var(--tint-rust-2);
+    padding: 6px 14px;
+    margin-bottom: 20px;
+  }
+
+  .lib-hero-title {
+    font-family: var(--font-display);
+    font-size: clamp(2.2em, 5vw, 3.4em);
+    color: var(--text-primary);
+    margin: 0 0 18px;
+    line-height: 1.1;
+  }
+
+  .lib-hero-desc {
+    font-size: 1.1em;
+    color: var(--text-secondary);
+    max-width: 620px;
+    margin: 0 auto 28px;
+    line-height: 1.6;
+  }
+
+  .lib-hero-cta {
+    display: flex;
+    gap: 16px;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .lib-hero-note {
+    margin-top: 20px;
+    font-size: 0.9em;
+    color: var(--text-secondary);
+  }
+
+  .lib-body {
+    padding: 60px 24px 100px;
+  }
+
+  .lib-body-inner {
+    max-width: 1080px;
+    margin: 0 auto;
+  }
+
+  .lib-cat-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 28px;
+  }
+
+  .lib-cat-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    border: 2px solid var(--border-color);
+    background: var(--bg-secondary);
+    padding: 28px;
+    text-decoration: none;
+    color: var(--text-primary);
+    box-shadow: var(--shadow-sm);
+    transition: all 0.25s ease;
+  }
+
+  .lib-cat-card:hover {
+    transform: translate(-4px, -4px);
+    box-shadow: 8px 8px 0 var(--mustard);
+    border-color: var(--rust);
+  }
+
+  .lib-cat-count {
+    position: absolute;
+    top: 18px;
+    right: 18px;
+    font-family: var(--font-display);
+    font-size: 0.85em;
+    color: var(--rust);
+    background: var(--tint-rust-2);
+    border: 1px solid var(--rust);
+    padding: 2px 10px;
+  }
+
+  .lib-cat-name {
+    font-family: var(--font-display);
+    font-size: 1.5em;
+    margin: 0 0 12px;
+    color: var(--text-primary);
+  }
+
+  .lib-cat-blurb {
+    font-size: 0.95em;
+    color: var(--text-secondary);
+    line-height: 1.55;
+    margin: 0 0 18px;
+    flex: 1;
+  }
+
+  .lib-cat-link {
+    font-size: 0.85em;
+    font-weight: 600;
+    color: var(--rust);
+    margin-top: auto;
+  }
+
+  @media (max-width: 768px) {
+    .lib-hero { padding: 120px 20px 40px; }
+    .lib-cat-grid { grid-template-columns: 1fr; gap: 20px; }
+  }
+</style>


### PR DESCRIPTION
## What

Phase 1 of the content/growth strategy: the free **Claude Code Marketing Library**. A curated directory of prompts, slash commands, subagents, and MCP lists for marketers using Claude Code, modeled on sheetsformarketers.com (hub-and-spoke, formulaic entry pages, copyable artifacts). Free entries are the SEO + email-capture magnet; paid packs come later once Polar is wired.

## Structure

- `library` content collection (Zod schema in `src/content.config.ts`). Paid fields (`access`, `polarProductId`, `polarCheckoutUrl`, `price`) are in the schema now so paid packs drop in later with no migration.
- Routes (static-generated): `/library/` hub, `/library/[category]/`, `/library/[category]/[entry]/`.
- 9 marketing-function categories, single source in `src/data/library-categories.ts`.
- Sitemap: `deriveLibraryUrls()` in `astro.config.mjs` (no hardcoded lists), entries 0.7, hub/category 0.8.
- Per-entry JSON-LD: SoftwareSourceCode + FAQPage + BreadcrumbList. Sidebar, breadcrumbs, related entries, generated Q&A.
- Helpers in `src/lib/library.ts`, components in `src/components/library/`.

## Seed content

13 free entries with real, copyable artifacts across all 9 categories (SEO, content, social, email, ads, analytics, reporting, competitive, project-ops). Bylines split Tri (technical/SEO) vs Alice (content/email/social).

## Verify

- `npm run build` completes; 23 library pages prerender (1 hub + 9 categories + 13 entries)
- sitemap-index includes all 23 library URLs at expected priorities
- entry JSON-LD types present: SoftwareSourceCode, FAQPage, BreadcrumbList, Person
- no em/en dashes; no changes to files owned by the phase-0 PR

## Deferred (follow-ups)

- Paid skill packs + Polar checkout UI (blocked on Polar integration)
- `## Marketing Library` section in llms.txt / llms-full.txt
- Main-nav link to `/library/` (lives in siteData.ts, owned by the phase-0 PR)
- Retrofit links from blog posts / Module 2 lessons into matching entries
- Master GitHub repo `cc4-marketing/marketing-library` (forward-linked from the hub)

Independent of PR #26 (phase-0 cleanup).
