### PR TITLE
fix(library): SSR routes, stop production redirect to Emdash setup

### DIFF
--- a/src/pages/library/[category]/[entry].astro
+++ b/src/pages/library/[category]/[entry].astro
@@ -1,6 +1,6 @@
 ---
-export const prerender = true;
-
+// SSR (not prerendered), matches the modules route so Emdash does not redirect
+// these paths to /_emdash/admin/setup in production.
 import { getCollection, render } from 'astro:content';
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 import Header from '../../../components/Header.astro';
@@ -17,15 +17,12 @@ import {
   metaFor,
 } from '../../../lib/library';
 
-export async function getStaticPaths() {
-  const entries = await getCollection('library');
-  return entries.map((entry) => ({
-    params: { category: entry.data.category, entry: fileSlug(entry) },
-    props: { entry, all: entries },
-  }));
-}
-
-const { entry, all } = Astro.props;
+const { category: categorySlug, entry: entrySlug } = Astro.params;
+const all = await getCollection('library');
+const entry = all.find(
+  (e) => e.data.category === categorySlug && fileSlug(e) === entrySlug,
+);
+if (!entry) return Astro.redirect('/404');
 const { data } = entry;
 const category = getCategory(data.category)!;
 const slug = fileSlug(entry);

--- a/src/pages/library/[category]/index.astro
+++ b/src/pages/library/[category]/index.astro
@@ -1,6 +1,6 @@
 ---
-export const prerender = true;
-
+// SSR (not prerendered), matches the modules route so Emdash does not redirect
+// these paths to /_emdash/admin/setup in production.
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 import Header from '../../../components/Header.astro';
@@ -10,22 +10,14 @@ import EntryCard from '../../../components/library/entry-card.astro';
 import { LIBRARY_CATEGORIES } from '../../../data/library-categories';
 import { fileSlug } from '../../../lib/library';
 
-export async function getStaticPaths() {
-  const entries = await getCollection('library');
-  return LIBRARY_CATEGORIES.map((cat) => ({
-    params: { category: cat.slug },
-    props: {
-      category: cat,
-      entries: entries
-        .filter((e) => e.data.category === cat.slug)
-        .sort((a, b) => a.data.name.localeCompare(b.data.name)),
-    },
-  }));
-}
-
-const { category, entries } = Astro.props;
+const { category: categorySlug } = Astro.params;
+const category = LIBRARY_CATEGORIES.find((c) => c.slug === categorySlug);
+if (!category) return Astro.redirect('/404');
 
 const allEntries = await getCollection('library');
+const entries = allEntries
+  .filter((e) => e.data.category === category.slug)
+  .sort((a, b) => a.data.name.localeCompare(b.data.name));
 const counts: Record<string, number> = {};
 for (const cat of LIBRARY_CATEGORIES) counts[cat.slug] = 0;
 for (const e of allEntries) counts[e.data.category] = (counts[e.data.category] ?? 0) + 1;

--- a/src/pages/library/index.astro
+++ b/src/pages/library/index.astro
@@ -1,6 +1,8 @@
 ---
-export const prerender = true;
-
+// SSR (not prerendered) so requests route through Astro like the modules pages.
+// Prerendered library routes were falling through to the Emdash SSR handler in
+// production and redirecting to /_emdash/admin/setup. Matching the modules SSR
+// pattern fixes that.
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Header from '../../components/Header.astro';


### PR DESCRIPTION
## Incident

After merging PR #27, every `/library/*` URL in production redirected to `/_emdash/admin/setup` (rest of the site fine). Confirmed on the origin worker via `cc4-mkt.mtri-vo.workers.dev` (bypasses the zone cache), so not a cache artifact.

## Cause

Library routes were prerendered (`export const prerender = true`). The prerendered `/library/*` assets fell through to the Emdash SSR handler in the deployed worker, which redirects unknown paths to the setup page. The `modules` routes are SSR (no prerender) and route cleanly through the same worker.

## Fix

Convert the 3 library routes to SSR dynamic, matching `src/pages/modules/[...slug].astro`:
- drop `export const prerender = true` and `getStaticPaths`
- read `Astro.params.category` / `Astro.params.entry` at request time
- redirect to `/404` on a miss

OG images (generated at build time) and the sitemap (filesystem-derived in astro.config) are unaffected.

## Verify

- `npm run build` completes
- local: `/library/`, category, and entry pages 200 with real content; an invalid category 302s to /404
- post-merge: will confirm on the origin worker that `/library/*` serves real content
