### PR TITLE
feat(library): hub/category OG covers + nav link

### DIFF
--- a/src/config/siteData.ts
+++ b/src/config/siteData.ts
@@ -5,6 +5,7 @@ export const siteData = {
   navItems: [
     { label: 'Home', href: '/' },
     { label: 'Modules', href: '/#modules' },
+    { label: 'Library', href: '/library/' },
     { label: 'Blog', href: '/blog/' },
     { label: 'Changelog', href: '/changelog/' },
     { label: 'GitHub', href: 'https://github.com/cc4-marketing/cc4.marketing', external: true },

--- a/src/lib/og/build.ts
+++ b/src/lib/og/build.ts
@@ -273,6 +273,37 @@ async function main(): Promise<void> {
     console.log(`✓ library/${key}.png (${(png.byteLength / 1024).toFixed(0)} KB)`);
   }
 
+  // --- Marketing Library hub + category covers ---
+  // The hub (/library/) and category (/library/{slug}/) pages are single or
+  // zero segment paths, so resolveOgImage maps them to these fixed keys rather
+  // than the two-segment entry keys above.
+  {
+    const hubHtml = renderLibraryTemplate({
+      name: 'Marketing Library',
+      categoryLabel: 'For Marketers',
+      typeLabel: 'Directory',
+      tagline: 'Free Claude Code prompts, slash commands, subagents, and MCP lists.',
+    });
+    const hubPng = await renderToPng(hubHtml);
+    writeFileSync(join(OUT_DIR, 'library', 'hub.png'), hubPng);
+    total += 1;
+    totalBytes += hubPng.byteLength;
+    console.log(`✓ library/hub.png (${(hubPng.byteLength / 1024).toFixed(0)} KB)`);
+  }
+  for (const cat of LIBRARY_CATEGORIES) {
+    const html = renderLibraryTemplate({
+      name: cat.label,
+      categoryLabel: 'Marketing Library',
+      typeLabel: 'Category',
+      tagline: cat.blurb,
+    });
+    const png = await renderToPng(html);
+    writeFileSync(join(OUT_DIR, 'library', `cat-${cat.slug}.png`), png);
+    total += 1;
+    totalBytes += png.byteLength;
+    console.log(`✓ library/cat-${cat.slug}.png (${(png.byteLength / 1024).toFixed(0)} KB)`);
+  }
+
   const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
   console.log(
     `\nGenerated ${total} OG images (${(totalBytes / 1024).toFixed(0)} KB total) in ${elapsed}s`,

--- a/src/lib/og/url.ts
+++ b/src/lib/og/url.ts
@@ -66,13 +66,22 @@ export async function resolveOgImage(
     return `/og/modules/${module}-${slug}.png`;
   }
 
+  // Library hub: /library/ → fixed build-time cover.
+  if (ctx.path === '/library' || ctx.path === '/library/') {
+    return '/og/library/hub.png';
+  }
+
   // Library entry pages: /library/{category}/{slug}/ → build-time OG asset.
-  // Two path segments required, so the hub and category index pages fall
-  // through to the default cover.
   const libraryMatch = ctx.path.match(/^\/library\/([^/]+)\/([^/]+)\/?$/);
   if (libraryMatch) {
     const [, category, slug] = libraryMatch;
     return `/og/library/${category}-${slug}.png`;
+  }
+
+  // Library category index: /library/{category}/ → per-category cover.
+  const libraryCatMatch = ctx.path.match(/^\/library\/([^/]+)\/?$/);
+  if (libraryCatMatch) {
+    return `/og/library/cat-${libraryCatMatch[1]}.png`;
   }
 
   return STATIC_FALLBACK_DEFAULT;


### PR DESCRIPTION
## What

Follow-up polish for the Marketing Library:

1. **OG covers for all library pages.** Entries already had per-entry covers; this adds a hub cover (`/og/library/hub.png`) and a per-category cover (`/og/library/cat-{slug}.png`), generated at build time by the OG engine. `resolveOgImage` maps `/library/` and `/library/{category}/` to them, so every library page now has a distinct social card instead of the generic default.
2. **Navigation.** Added a `Library` link to the main nav (desktop and mobile), between Modules and Blog.
3. **robots + sitemap.** No change needed: robots.txt already allows `/library/` and references the sitemap; library URLs are in the sitemap via `deriveLibraryUrls()`. Verified.

## Verify

- `npm run build` generates `hub.png` + 9 `cat-*.png`
- local: hub page emits `og/library/hub.png`, `/library/seo/` emits `og/library/cat-seo.png`, entries unchanged; nav shows Library
- post-merge: confirm live OG tags + sitemap contains library URLs
