### PR TITLE
feat(library): fold /skills into library (cart, download, 4 skills)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -116,7 +116,8 @@ export default defineConfig({
       filter: (page) =>
         !page.includes('/og-preview') &&
         !page.includes('/og/preview') &&
-        !page.includes('/og/debug'),
+        !page.includes('/og/debug') &&
+        !page.includes('/library/download/'),
       serialize(item) {
         const url = item.url;
         // No lastmod: stamping build time on every URL told Google all pages

--- a/plans/20260722-0210-library-skills-fold/plan.md
+++ b/plans/20260722-0210-library-skills-fold/plan.md
@@ -1,0 +1,31 @@
+# Fold /skills (PR #25) into the Marketing Library
+
+Decision: one directory. Keep every library file on main, port only net-new mechanics from PR #25 (cart, R2 download, tabbed install). Close #25.
+
+## Packaging (gh repo vs R2): split by tier
+- Free skills: public GitHub repo, `git clone <repo> ~/.claude/skills/<slug>`. Versioned, PR-able, transparent, flywheel, native install shape.
+- Paid packs: R2 gated download via Polar (later). Protects paid source; single file for non-tech buyers.
+
+## Mechanics to port (net-new only)
+1. Schema (`content.config.ts` libraryCollection): add optional `repoUrl`, `downloadKey` (skill-only). Skip `installCmd` (YAGNI).
+2. Cart: port `SkillCart.astro` -> `src/components/library/stack-cart.astro`, route-agnostic via data-attrs (`data-download-url`, `data-page-url`). Render add-to-stack ONLY on `type: skill` (and future paid packs). Not on prompt/command/subagent/mcp.
+3. Download route: `src/pages/library/download/[slug].skill.ts` (SSR, R2 `MEDIA`, slug-validated via `getLibraryEntryBySlug`, 404-not-500, noindex). Exclude `/library/download/*` from sitemap filter.
+4. Detail page (`library/[category]/[entry].astro`): conditional `{type === 'skill'}` block: tabbed install (git clone / download), View on GitHub, add-to-stack + one `<StackCart/>`. Swap JSON-LD to `SoftwareApplication` for skill type; keep `SoftwareSourceCode` for the other 4. Zero change to 16 non-skill entries.
+5. `CodeBlockCopy.astro`: add the one-line `[data-no-copy-btn]` skip.
+6. Helper: `getLibraryEntryBySlug(slug)` in `src/lib/library.ts` (globally-unique skill slugs).
+
+## Drop from #25 (library already owns these)
+skills routes, skills collection, Skills nav entry, skillPages sitemap branch, skills OgPageKey, separate llms Skills section. Close PR #25. Add defensive 301 `/skills` and `/skills/*` -> `/library/`.
+
+## Skills to bring (user pick)
+- notes-humanizer (content, FREE): ship now via public repo, working git clone. Proves the pattern.
+- campaign-review (project-ops, PAID), last-30-days (competitive, PAID), pptx deck (reporting, PAID): add as skill entries, access: paid, install gated until Polar. Preview + "install at launch".
+
+## Sequencing
+- Phase A: fold mechanics (schema, cart, download route, detail UI, CodeBlockCopy, helper, sitemap). Build green.
+- Phase B: 4 skill entries; publish notes-humanizer to a public repo, set repoUrl. Paid 3 as preview entries.
+- Close #25, 301 redirect, deploy, verify.
+
+## Open
+- notes-humanizer repo home: dedicated `cc4-marketing/skills` vs a folder in `cc4-marketing/marketing-library`. Recommend dedicated repo so `git clone <repo> ~/.claude/skills/notes-humanizer` lands clean.
+- Category for cross-cutting skills: content/project-ops per skill; no new category.

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -217,9 +217,11 @@ Entries:
 - UTM Builder (https://cc4.marketing/library/analytics/utm-builder/): Build consistent UTM tagged URLs from your naming rules and flag drift.
 - Competitor Page Teardown (https://cc4.marketing/library/competitive/competitor-page-teardown/): Analyze one competitor landing page for offer, proof, CTA, and gaps.
 - Content Gap Finder (https://cc4.marketing/library/competitive/content-gap-finder/): Compare a competitor's topic coverage to yours and rank the gaps to target.
+- Last 30 Days (https://cc4.marketing/library/competitive/last-30-days/): Skill that reads recent community opinion on a tool or trend across Reddit, X, and web.
 - Blog Post Outline Builder (https://cc4.marketing/library/content/blog-post-outline/): Turn a keyword into an H2 and H3 outline with intent notes.
 - Brand Voice Memory Block (https://cc4.marketing/library/content/brand-voice-memory/): A CLAUDE.md block that keeps every draft on brand across a project.
 - Blog to Social Repurposer (https://cc4.marketing/library/content/repurpose-blog-to-social/): Turn one blog post into a LinkedIn post, an X thread, and a carousel.
+- Notes Humanizer (https://cc4.marketing/library/content/notes-humanizer/): Skill that strips AI tells from a draft so it reads like a person wrote it.
 - Newsletter Section from a Link (https://cc4.marketing/library/email/newsletter-from-link/): Summarize a URL into a newsletter section with subject line and CTA.
 - Welcome Sequence Outline (https://cc4.marketing/library/email/welcome-sequence-outline/): Outline a 4 to 5 email onboarding drip with goal, subject, and CTA per email.
 - Resend Setup Audit (https://cc4.marketing/library/email/resend-setup-audit/): Audit a Resend setup end to end (domain, DMARC, tracking, broadcast hygiene) with proof per item.
@@ -227,8 +229,10 @@ Entries:
 - Negative Keyword Finder (https://cc4.marketing/library/paid-ads/negative-keyword-finder/): Mine a Google Ads search terms export for negative keywords, grouped by reason.
 - Content Calendar Scaffold (https://cc4.marketing/library/project-ops/content-calendar-scaffold/): Build a 90 day rolling content calendar from a short description.
 - Marketing MCP Starter (https://cc4.marketing/library/project-ops/marketing-mcp-starter/): A starter set of MCP servers marketers actually use with Claude Code.
+- Campaign Review Dashboard (https://cc4.marketing/library/project-ops/campaign-review/): Skill that turns a campaign folder into one HTML page a client can review in full.
 - Weekly Metrics Summary (https://cc4.marketing/library/reporting/weekly-metrics-summary/): Turn a metrics CSV into a plain language weekly readout with deltas.
 - Monthly Report Outline (https://cc4.marketing/library/reporting/monthly-report-outline/): Produce an executive monthly marketing report outline leaders will read.
+- Slide Deck Builder (https://cc4.marketing/library/reporting/slide-deck-builder/): Skill that builds and edits real PowerPoint decks for pitches and readouts.
 - Content Brief Generator (https://cc4.marketing/library/seo/content-brief-generator/): Turn one keyword into a full SEO content brief a writer can follow.
 - Meta Title and Description Writer (https://cc4.marketing/library/seo/meta-title-description-writer/): Write SERP length checked title and description pairs that fit Google.
 - SERP Intent Classifier (https://cc4.marketing/library/seo/serp-intent-classifier/): Label a keyword list by search intent, with a reason for each call.

--- a/src/components/CodeBlockCopy.astro
+++ b/src/components/CodeBlockCopy.astro
@@ -13,6 +13,10 @@
         return;
       }
 
+      // Skip opt-out containers (e.g. the stack cart's command block, which
+      // ships its own "Copy all" control).
+      if (pre.closest('[data-no-copy-btn]')) return;
+
       // Create wrapper
       const wrapper = document.createElement('div');
       wrapper.className = 'code-block-wrapper';

--- a/src/components/library/stack-cart.astro
+++ b/src/components/library/stack-cart.astro
@@ -1,0 +1,447 @@
+---
+// Persistent "stack" cart: select library skills across pages, then check out
+// with one combined install block. State lives in localStorage so it survives
+// navigation. Vanilla JS to match the site's zero-framework idiom (see
+// CodeBlockCopy.astro).
+//
+// Route-agnostic: the cart never builds /library paths itself. Each add control
+// carries its own data attributes, which the cart reads verbatim:
+//   [data-skill-add] data-slug data-name data-repo data-download-url data-page-url
+// Render <StackCart /> once per page that has add controls.
+---
+
+<div id="lib-stack" class="lib-stack" hidden aria-live="polite">
+  <div class="lib-stack-bar">
+    <button type="button" id="lib-stack-toggle" class="lib-stack-toggle" aria-expanded="false" aria-controls="lib-stack-panel">
+      <span class="lib-stack-icon" aria-hidden="true">🎒</span>
+      <span class="lib-stack-label">Your stack</span>
+      <span id="lib-stack-count" class="lib-stack-count">0</span>
+    </button>
+    <button type="button" id="lib-stack-checkout" class="lib-stack-checkout">Check out</button>
+  </div>
+</div>
+
+<div id="lib-stack-panel" class="lib-stack-panel" hidden role="dialog" aria-modal="true" aria-labelledby="lib-stack-panel-title">
+  <div class="lib-stack-panel-inner">
+    <header class="lib-stack-panel-head">
+      <h2 id="lib-stack-panel-title">Install your stack</h2>
+      <button type="button" id="lib-stack-close" class="lib-stack-close" aria-label="Close">✕</button>
+    </header>
+
+    <p class="lib-stack-panel-sub">
+      Run these from your terminal to add every selected skill to Claude Code, then restart it.
+    </p>
+
+    <div class="lib-stack-commands" data-no-copy-btn>
+      <button type="button" id="lib-stack-copyall" class="lib-stack-copyall">Copy all commands</button>
+      <pre id="lib-stack-script"><code></code></pre>
+    </div>
+
+    <div id="lib-stack-downloads" class="lib-stack-downloads">
+      <h3>Or download the packaged skills</h3>
+      <ul id="lib-stack-download-list"></ul>
+    </div>
+
+    <footer class="lib-stack-panel-foot">
+      <button type="button" id="lib-stack-clear" class="lib-stack-clear">Clear stack</button>
+    </footer>
+  </div>
+</div>
+
+<script>
+  type CartItem = {
+    slug: string;
+    name: string;
+    repo?: string;
+    downloadUrl?: string;
+    pageUrl?: string;
+  };
+
+  const KEY = 'cc4m-library-stack';
+
+  function read(): CartItem[] {
+    try {
+      const raw = localStorage.getItem(KEY);
+      const parsed = raw ? JSON.parse(raw) : [];
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+
+  function write(items: CartItem[]): void {
+    try {
+      localStorage.setItem(KEY, JSON.stringify(items));
+    } catch {
+      /* storage unavailable (private mode): cart is in-memory for this view */
+    }
+  }
+
+  function cloneCommand(item: CartItem): string {
+    if (item.repo) return `git clone ${item.repo} ~/.claude/skills/${item.slug}`;
+    return `# ${item.name}: see ${item.pageUrl ?? ''} for install steps`;
+  }
+
+  function buildScript(items: CartItem[]): string {
+    if (items.length === 0) return '';
+    return [
+      '# CC4.Marketing library stack, run these, then restart Claude Code',
+      'mkdir -p ~/.claude/skills',
+      ...items.map(cloneCommand),
+    ].join('\n');
+  }
+
+  function setupStackCart(): void {
+    const cart = document.getElementById('lib-stack');
+    const panel = document.getElementById('lib-stack-panel');
+    if (!cart || !panel) return;
+
+    const countEl = document.getElementById('lib-stack-count')!;
+    const scriptEl = panel.querySelector<HTMLElement>('#lib-stack-script code')!;
+    const downloadsEl = document.getElementById('lib-stack-downloads')!;
+    const downloadList = document.getElementById('lib-stack-download-list')!;
+
+    // Always start closed so back/forward (pageshow) never restores it mid-open.
+    panel.hidden = true;
+
+    function refreshAddButtons(items: CartItem[]): void {
+      const slugs = new Set(items.map((i) => i.slug));
+      document.querySelectorAll<HTMLElement>('[data-skill-add]').forEach((btn) => {
+        const inStack = slugs.has(btn.dataset.slug || '');
+        btn.classList.toggle('in-stack', inStack);
+        btn.setAttribute('aria-pressed', String(inStack));
+        const label = btn.querySelector('[data-add-label]');
+        if (label) label.textContent = inStack ? 'In stack ✓' : 'Add to stack';
+      });
+    }
+
+    function render(): void {
+      const items = read();
+      countEl.textContent = String(items.length);
+      cart.hidden = items.length === 0;
+
+      scriptEl.textContent = buildScript(items);
+
+      const withFiles = items.filter((i) => i.downloadUrl);
+      downloadsEl.hidden = withFiles.length === 0;
+      downloadList.innerHTML = '';
+      for (const item of withFiles) {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = item.downloadUrl!;
+        a.setAttribute('download', `${item.slug}.skill`);
+        a.textContent = `${item.name} (.skill)`;
+        li.appendChild(a);
+        downloadList.appendChild(li);
+      }
+
+      refreshAddButtons(items);
+    }
+
+    function toggleItem(data: CartItem): void {
+      const items = read();
+      const idx = items.findIndex((i) => i.slug === data.slug);
+      if (idx >= 0) items.splice(idx, 1);
+      else items.push(data);
+      write(items);
+      render();
+    }
+
+    function openPanel(): void {
+      if (read().length === 0) return;
+      panel.hidden = false;
+      document.getElementById('lib-stack-toggle')?.setAttribute('aria-expanded', 'true');
+      (document.getElementById('lib-stack-close') as HTMLElement | null)?.focus();
+    }
+
+    function closePanel(): void {
+      panel.hidden = true;
+      document.getElementById('lib-stack-toggle')?.setAttribute('aria-expanded', 'false');
+    }
+
+    // Delegated add-button wiring (idempotent via data-cartBound).
+    document.querySelectorAll<HTMLElement>('[data-skill-add]').forEach((btn) => {
+      if (btn.dataset.cartBound) return;
+      btn.dataset.cartBound = '1';
+      btn.addEventListener('click', (e) => {
+        e.preventDefault();
+        toggleItem({
+          slug: btn.dataset.slug || '',
+          name: btn.dataset.name || btn.dataset.slug || '',
+          repo: btn.dataset.repo || undefined,
+          downloadUrl: btn.dataset.downloadUrl || undefined,
+          pageUrl: btn.dataset.pageUrl || undefined,
+        });
+      });
+    });
+
+    document.getElementById('lib-stack-checkout')?.addEventListener('click', openPanel);
+    document.getElementById('lib-stack-toggle')?.addEventListener('click', openPanel);
+    document.getElementById('lib-stack-close')?.addEventListener('click', closePanel);
+    panel.addEventListener('click', (e) => {
+      if (e.target === panel) closePanel();
+    });
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && !panel.hidden) closePanel();
+    });
+
+    document.getElementById('lib-stack-clear')?.addEventListener('click', () => {
+      write([]);
+      render();
+      closePanel();
+    });
+
+    const copyAll = document.getElementById('lib-stack-copyall');
+    copyAll?.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(buildScript(read()));
+        const prev = copyAll.textContent;
+        copyAll.textContent = 'Copied!';
+        copyAll.classList.add('copied');
+        setTimeout(() => {
+          copyAll.textContent = prev;
+          copyAll.classList.remove('copied');
+        }, 2000);
+      } catch (err) {
+        console.error('Copy failed', err);
+      }
+    });
+
+    // Reflect changes made in other tabs/pages.
+    window.addEventListener('storage', (e) => {
+      if (e.key === KEY) render();
+    });
+
+    render();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setupStackCart);
+  } else {
+    setupStackCart();
+  }
+  window.addEventListener('pageshow', setupStackCart);
+</script>
+
+<style>
+  /* [hidden] must win over the tray's display:flex, else it never auto-hides. */
+  .lib-stack[hidden],
+  .lib-stack-panel[hidden] {
+    display: none !important;
+  }
+
+  .lib-stack {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 50;
+    display: flex;
+    justify-content: center;
+    padding: 0 16px 16px;
+    pointer-events: none;
+  }
+
+  .lib-stack-bar {
+    pointer-events: auto;
+    display: flex;
+    align-items: stretch;
+    background: var(--bg-secondary);
+    border: 2px solid var(--charcoal);
+    box-shadow: 6px 6px 0 var(--mustard);
+    max-width: 480px;
+    width: 100%;
+  }
+
+  .lib-stack-toggle {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: transparent;
+    border: none;
+    border-right: 2px solid var(--border-color);
+    padding: 14px 18px;
+    font-size: 0.95em;
+    font-weight: 600;
+    color: var(--text-primary);
+    cursor: pointer;
+  }
+
+  .lib-stack-icon { font-size: 1.2em; }
+
+  .lib-stack-count {
+    margin-left: auto;
+    min-width: 24px;
+    height: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--rust);
+    color: var(--cream);
+    font-size: 0.8em;
+    font-weight: 700;
+    border-radius: 999px;
+    padding: 0 7px;
+  }
+
+  .lib-stack-checkout {
+    background: var(--rust);
+    color: var(--cream);
+    border: none;
+    padding: 14px 22px;
+    font-size: 0.95em;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background 0.2s ease;
+  }
+
+  .lib-stack-checkout:hover { background: var(--charcoal); }
+
+  .lib-stack-panel {
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+  }
+
+  .lib-stack-panel-inner {
+    background: var(--bg-primary);
+    border: 2px solid var(--charcoal);
+    box-shadow: 8px 8px 0 var(--mustard);
+    max-width: 640px;
+    width: 100%;
+    max-height: 85vh;
+    overflow-y: auto;
+    padding: 28px;
+  }
+
+  .lib-stack-panel-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+  }
+
+  .lib-stack-panel-head h2 {
+    font-family: var(--font-display);
+    font-size: 1.5em;
+    margin: 0;
+    color: var(--text-primary);
+  }
+
+  .lib-stack-close {
+    background: transparent;
+    border: 2px solid var(--border-color);
+    width: 36px;
+    height: 36px;
+    font-size: 1em;
+    cursor: pointer;
+    color: var(--text-primary);
+  }
+
+  .lib-stack-close:hover { border-color: var(--rust); color: var(--rust); }
+
+  .lib-stack-panel-sub {
+    color: var(--text-secondary);
+    font-size: 0.95em;
+    margin: 0 0 20px;
+  }
+
+  .lib-stack-commands {
+    position: relative;
+    margin-bottom: 24px;
+    border: 2px solid #2a2a2a;
+    background: #1c1c1c;
+  }
+
+  .lib-stack-copyall {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    background: #2d2d2d;
+    border: 1px solid #4a4a4a;
+    color: #eaeaea;
+    font-size: 0.8em;
+    font-weight: 600;
+    padding: 5px 12px;
+    cursor: pointer;
+    z-index: 1;
+  }
+
+  .lib-stack-copyall:hover { border-color: var(--rust); color: var(--rust); }
+  .lib-stack-copyall.copied { border-color: #7fb069; color: #7fb069; }
+
+  .lib-stack-commands pre {
+    background: transparent;
+    color: #eaeaea;
+    border: none;
+    padding: 16px;
+    padding-top: 40px;
+    margin: 0;
+    font-size: 0.85em;
+    line-height: 1.6;
+    /* Wrap long clone commands rather than horizontal-scroll. */
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+
+  .lib-stack-commands pre code {
+    color: inherit;
+    background: transparent;
+    border: none;
+    padding: 0;
+  }
+
+  .lib-stack-downloads h3 {
+    font-family: var(--font-display);
+    font-size: 1em;
+    color: var(--text-primary);
+    margin: 0 0 12px;
+  }
+
+  #lib-stack-download-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 20px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  #lib-stack-download-list a {
+    display: inline-block;
+    font-size: 0.85em;
+    font-weight: 600;
+    color: var(--rust);
+    border: 2px solid var(--rust);
+    padding: 6px 14px;
+    text-decoration: none;
+  }
+
+  #lib-stack-download-list a:hover { background: var(--rust); color: var(--cream); }
+
+  .lib-stack-panel-foot {
+    border-top: 2px solid var(--border-color);
+    padding-top: 16px;
+  }
+
+  .lib-stack-clear {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 0.85em;
+    cursor: pointer;
+    text-decoration: underline;
+  }
+
+  .lib-stack-clear:hover { color: var(--rust); }
+
+  @media (max-width: 640px) {
+    .lib-stack-panel-inner { padding: 20px; }
+  }
+</style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -48,6 +48,10 @@ const libraryCollection = defineCollection({
     publishedAt: z.coerce.date().optional(),
     metaDescription: z.string().max(160).optional(),
     faq: z.array(z.object({ q: z.string(), a: z.string() })).optional(),
+    // Skill-only in practice: source repo (clone target) and the R2 object
+    // suffix under skills/ that the download route streams.
+    repoUrl: z.string().url().optional(),
+    downloadKey: z.string().optional(),
   }),
 });
 

--- a/src/content/library/competitive/last-30-days.mdx
+++ b/src/content/library/competitive/last-30-days.mdx
@@ -1,0 +1,50 @@
+---
+name: Last 30 Days
+category: competitive
+type: skill
+tagline: Read what people actually said about a tool or trend in the last month.
+description: "A Claude Code skill that researches recent (30 days or newer) community opinion on a tool or trend across Reddit, X, and the web, then synthesizes what operators agree on, what they contest, and the quiet pain that marketing pages leave out."
+access: paid
+price: 19.99
+related:
+  - competitor-page-teardown
+  - content-gap-finder
+  - marketing-mcp-starter
+author: tri-vo
+tags:
+  - competitive
+  - market research
+  - sentiment
+updatedAt: 2026-07-22
+publishedAt: 2026-07-22
+metaDescription: "A Claude Code skill that pulls the last 30 days of real opinion on a tool or trend from Reddit, X, and web, then synthesizes consensus and dissent."
+faq:
+  - q: "Why cap it at 30 days?"
+    a: "Because sentiment shifts fast and older threads bias toward stale narratives. A tool that was loved a year ago may be leaking users this month after a pricing change or an incident. The recency filter keeps you reading what people think now, which is what a launch angle has to survive."
+  - q: "What does the output look like?"
+    a: "Three sections. Consensus is two to four bullets of what most operators agree on. Disagreement is one to three contested points with the camps named. Quiet pain is one to three issues people raise that the marketing never mentions. Each bullet cites its source domain."
+  - q: "How is this different from a normal web search?"
+    a: "It reads opinion, not documentation. It pulls from Reddit, X, Hacker News, GitHub issue tone, and public forums, then synthesizes the pattern across them rather than handing you ten links. You get the operator view, not the vendor's own page."
+---
+
+Before you commit a campaign angle, you want to know what people actually think about the tool or trend right now, not what its landing page claims and not what a review wrote a year ago. Last 30 Days is a Claude Code skill that pulls recent opinion from where operators talk (Reddit, X, the wider web) and tells you what they agree on, what they fight about, and what quietly breaks. Use it to validate a message or read launch sentiment before you spend on it.
+
+## What it does
+
+Give it a tool, library, or trend and it runs recency-focused research, filtered to the last 30 days, and returns a synthesis in three parts.
+
+- **Consensus.** Two to four bullets of what most operators agree on.
+- **Disagreement.** One to three contested points, with the camps named so you know who thinks what.
+- **Quiet pain.** One to three issues people raise that never show up in the marketing.
+
+It reads opinion rather than docs, drawing from Reddit, X, Hacker News, blog comments, GitHub issue tone, and public forum summaries. Every bullet cites its source domain so you can trace a claim back.
+
+## When a marketer reaches for it
+
+- Validating a campaign angle against how the audience actually talks about the category.
+- Reading sentiment after a competitor's launch, price change, or incident.
+- Separating vendor hype from operator experience before you echo a claim in your own copy.
+
+## Install
+
+This skill is part of a paid pack. Install will be available at launch. Add it to your stack with the button above and you will get the install link when the pack ships.

--- a/src/content/library/content/notes-humanizer.mdx
+++ b/src/content/library/content/notes-humanizer.mdx
@@ -1,0 +1,62 @@
+---
+name: Notes Humanizer
+category: content
+type: skill
+tagline: Strip the AI tells out of a draft so it reads like a person wrote it.
+description: "A Claude Code skill that removes machine-written patterns from copy (em dashes, 'delve', 'leverage', empty transitions) and adds back specifics, one real opinion, and varied sentence rhythm before you publish."
+access: free
+repoUrl: https://github.com/cc4-marketing/notes-humanizer
+related:
+  - brand-voice-memory
+  - repurpose-blog-to-social
+  - blog-post-outline
+author: alice-marketer
+tags:
+  - content
+  - copy editing
+  - ai detection
+updatedAt: 2026-07-22
+publishedAt: 2026-07-22
+metaDescription: "A Claude Code skill that strips AI tells from copy (em dashes, 'delve', flat phrasing) and adds specifics and voice, so drafts read human before you ship."
+faq:
+  - q: "What exactly does it strip out?"
+    a: "The patterns that flag text as machine-written: em dashes used for clause breaks, words like 'delve', 'leverage', and 'utilize', the 'it's not just X, it's Y' tic, hedging adverbs such as 'essentially' and 'ultimately', and empty transitions like 'moreover' and 'furthermore'."
+  - q: "Does it change what my copy says?"
+    a: "No. It keeps your meaning and rewrites the texture. It cuts the mechanical phrasing, then adds a concrete number or name roughly every 80 words, one opinion an AI would not volunteer, and sentence-length variance so the rhythm sounds human."
+  - q: "When in my workflow should I run it?"
+    a: "Last, right before publishing. Draft the piece however you like, then run the skill as a final pass on newsletters, Substack notes, X posts, or landing-page body copy."
+---
+
+Most AI drafts read smooth and say nothing. They lean on the same tells: em dashes splitting every other sentence, words like "delve" and "leverage", the "it's not just X, it's Y" construction, and transitions that add no information. Readers clock that tone now, and so do AI detectors. Notes Humanizer is a Claude Code skill that runs as a final pass on a draft, cuts those patterns, and puts a human voice back in. You keep the AI speed and ship copy that does not sound like a model wrote it.
+
+## What it does
+
+The skill works in two passes.
+
+**Strip pass.** It removes the default set of AI tells:
+
+- Em dashes used for clause separation.
+- "Delve", "leverage", "utilize", "in today's fast-paced", "navigate the landscape".
+- The "it's not just X, it's Y" pattern.
+- Overuse of trios (the "X, Y, and Z" structure on repeat).
+- Hedging adverbs: "essentially", "fundamentally", "ultimately".
+- Empty transitions: "moreover", "furthermore", "in conclusion".
+
+**Inject pass.** It adds what a flat draft is missing:
+
+- One concrete number or proper noun about every 80 words.
+- One opinion or preference a model would not volunteer on its own.
+- Sentence-length variance, mixing short punchlines with longer setups.
+- A voice quirk that matches your prior writing.
+
+The result reads like one person wrote it on a good day, not like a template got filled in.
+
+## Install
+
+This one is free. Clone it straight into your Claude Code skills directory, then restart Claude Code.
+
+```bash
+git clone https://github.com/cc4-marketing/notes-humanizer ~/.claude/skills/notes-humanizer
+```
+
+Once it is installed, draft your copy as usual and ask Claude to run the notes-humanizer skill on it before you publish. Use the git clone tab above to copy the exact command.

--- a/src/content/library/project-ops/campaign-review.mdx
+++ b/src/content/library/project-ops/campaign-review.mdx
@@ -1,0 +1,51 @@
+---
+name: Campaign Review Dashboard
+category: project-ops
+type: skill
+tagline: Turn a campaign folder into one HTML page a client can review in full.
+description: "A Claude Code skill that scans a campaign workspace and builds a single self-contained HTML dashboard: asset inventory with statuses, an open-items checklist, and an inline viewer that renders every file, plus an optional zip you can send."
+access: paid
+price: 19.99
+related:
+  - content-calendar-scaffold
+  - marketing-mcp-starter
+  - monthly-report-outline
+author: tri-vo
+tags:
+  - project ops
+  - campaign management
+  - client review
+updatedAt: 2026-07-22
+publishedAt: 2026-07-22
+metaDescription: "A Claude Code skill that turns a campaign folder into one HTML dashboard: asset inventory, statuses, open items, and an inline viewer for every file."
+faq:
+  - q: "What goes into the dashboard?"
+    a: "A top overview with a stat band and the campaign's proof numbers, one table per asset group with a status tag on each item (done, live, verify, hold, or choose), an open-items checklist with owners, and a knowledge summary. Below that, an inline viewer embeds every file: markdown renders, HTML and PDF embed, and binaries link out."
+  - q: "Can I send it to someone who does not have the files?"
+    a: "Yes. Run it with the zip option and the skill packages the review page plus every included file and referenced asset into one archive. Whoever you send it to extracts the zip and opens the page offline, with all the inline views and download links intact."
+  - q: "Where do the asset statuses come from?"
+    a: "From your own plan files and prior reports, not invented. The skill reads the phase tables and status notes already in the workspace, so the dashboard reflects the real state of the campaign rather than a guess."
+---
+
+When a campaign is spread across a dozen files (briefs, landing pages, ad copy, PDFs, a plan), handing someone a folder is a bad review experience. They have to open each file, guess what is done, and ping you for status. Campaign Review Dashboard is a Claude Code skill that reads the whole workspace and builds one HTML page: the campaign overview on top, every file readable inline below it. You send one link, and a client or manager reviews the entire campaign without opening anything else.
+
+## What it does
+
+Point the skill at a campaign folder and it produces a single self-contained HTML file with two parts.
+
+**The overview.** A title and meta line (product, engagement, date), a stat band with the campaign's proof numbers, one table per asset group with a status tag on each item (done, live, verify, hold, or choose), an open-items checklist with owner labels, and a short knowledge summary of what the campaign encodes. Statuses come from your plan files and prior reports, so they match reality.
+
+**The inline viewer.** Every campaign file, embedded on the same page. Markdown renders to formatted text, HTML and PDF embed in place, and binaries link out. The sidebar lists every file so a reviewer can jump straight to one. Each section has copy and open-in-editor controls, and markdown sections can be edited and saved as a timestamped version.
+
+Add the zip option and the skill packages the review page plus every included file and referenced asset (fonts, images, logos) into one archive that opens offline anywhere.
+
+## How to use
+
+1. Ask Claude to run the campaign review skill on your campaign workspace.
+2. It scans the default roots (docs, marketing, plans) and asks you to confirm if the campaign root is ambiguous.
+3. It writes the overview, embeds every file, self-validates the output, and opens the finished page.
+4. When you want to send it, ask for the zip and hand off the single archive.
+
+## Install
+
+This skill is part of a paid pack. Install will be available at launch. Add it to your stack now with the button above and you will get the install link when the pack ships.

--- a/src/content/library/reporting/slide-deck-builder.mdx
+++ b/src/content/library/reporting/slide-deck-builder.mdx
@@ -1,0 +1,48 @@
+---
+name: Slide Deck Builder
+category: reporting
+type: skill
+tagline: Build and edit real PowerPoint decks, not markdown, for pitches and readouts.
+description: "A Claude Code skill that creates and edits genuine .pptx presentations with proper layouts, charts, tables, and speaker notes, so pitch decks and client readouts ship as files people can open and present in PowerPoint or Keynote."
+access: paid
+price: 19.99
+related:
+  - monthly-report-outline
+  - weekly-metrics-summary
+  - campaign-review
+author: tri-vo
+tags:
+  - reporting
+  - presentations
+  - client readouts
+updatedAt: 2026-07-22
+publishedAt: 2026-07-22
+metaDescription: "A Claude Code skill that builds and edits real .pptx decks with layouts, charts, and speaker notes, so pitches and readouts ship as files, not markdown."
+faq:
+  - q: "Does it output a real .pptx file?"
+    a: "Yes. It writes a genuine PowerPoint file that opens in PowerPoint, Keynote, and Google Slides, with real layouts, charts, tables, and speaker notes. It is not markdown or a slide image, so the client can edit the deck after you hand it over."
+  - q: "Can it work from a template we already use?"
+    a: "Yes. Point it at an existing .pptx and it reads the layouts and design, then duplicates and fills the template slides with your content so the new deck matches your house style instead of a generic theme."
+  - q: "Can it edit a deck I already have?"
+    a: "Yes. It can open an existing presentation, change the content on specific slides, and save it back, so you can refresh last quarter's readout rather than rebuild it from a blank file."
+---
+
+Claude is good at drafting the story of a deck, but a client cannot present a markdown outline. Slide Deck Builder is a Claude Code skill that produces genuine .pptx files: real layouts, charts, tables, and speaker notes, the kind of deck someone opens in PowerPoint or Keynote and presents from. Use it for pitch decks, monthly readouts, and campaign proposals when the deliverable has to be a file, not a document.
+
+## What it does
+
+- **Builds decks from scratch.** It picks a layout and palette to match the topic, lays out each slide with a clear hierarchy, adds charts and tables where the data belongs, and writes speaker notes. It validates the output visually and fixes text cutoff or overlap before handing it over.
+- **Works from your template.** Point it at an existing .pptx and it reads the layouts, then duplicates and fills them with your content so the deck keeps your brand instead of a stock theme.
+- **Edits existing decks.** It opens a presentation, changes the content on the slides you name, and saves it back, so refreshing a prior readout does not mean rebuilding it.
+
+The result is a file you send as is: charts render, notes travel with the slides, and the recipient can keep editing.
+
+## When a marketer reaches for it
+
+- A client pitch or proposal that has to arrive as a polished .pptx.
+- A monthly or quarterly readout where the numbers belong on charts, not in a table dump.
+- Reskinning a strong draft into the client's own template before a meeting.
+
+## Install
+
+This skill is part of a paid pack. Install will be available at launch. Add it to your stack with the button above and you will get the install link when the pack ships.

--- a/src/lib/library.ts
+++ b/src/lib/library.ts
@@ -1,4 +1,5 @@
 import type { CollectionEntry } from 'astro:content';
+import { getCollection } from 'astro:content';
 import { TYPE_LABELS } from '../data/library-categories';
 
 export type LibraryEntry = CollectionEntry<'library'>;
@@ -88,6 +89,24 @@ export function resolveRelated(entry: LibraryEntry, all: LibraryEntry[]): Librar
   }
 
   return picked.slice(0, 5);
+}
+
+/**
+ * Look up a skill entry by its file slug for the install/download routes.
+ * Returns null unless the slug matches a `type: 'skill'` entry that carries a
+ * repoUrl or downloadKey. Slugs are assumed globally unique, so the download
+ * route can trust this as its allow-list before touching R2.
+ */
+export async function getLibraryEntryBySlug(slug: string): Promise<LibraryEntry | null> {
+  if (!slug) return null;
+  const all = await getCollection('library');
+  const match = all.find(
+    (e) =>
+      fileSlug(e) === slug &&
+      e.data.type === 'skill' &&
+      (e.data.repoUrl || e.data.downloadKey),
+  );
+  return match ?? null;
 }
 
 export interface FaqPair {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,6 +9,12 @@ export const onRequest = defineMiddleware((context, next) => {
   const url = new URL(request.url);
   const { pathname } = url;
 
+  // The /skills gallery never shipped: it was folded into /library/. Any
+  // pre-merge shares or stray index entries get a 301 to the library hub.
+  if (pathname === '/skills' || pathname.startsWith('/skills/')) {
+    return context.redirect('/library/', 301);
+  }
+
   const isPage =
     !pathname.endsWith('/') &&
     !pathname.startsWith('/api/') &&

--- a/src/pages/library/[category]/[entry].astro
+++ b/src/pages/library/[category]/[entry].astro
@@ -7,6 +7,7 @@ import Header from '../../../components/Header.astro';
 import Footer from '../../../components/Footer.astro';
 import CategorySidebar from '../../../components/library/category-sidebar.astro';
 import EntryCard from '../../../components/library/entry-card.astro';
+import StackCart from '../../../components/library/stack-cart.astro';
 import { LIBRARY_CATEGORIES, getCategory } from '../../../data/library-categories';
 import {
   fileSlug,
@@ -38,6 +39,12 @@ const { Content } = await render(entry);
 const siteUrl = 'https://cc4.marketing';
 const pageUrl = `${siteUrl}/library/${data.category}/${slug}/`;
 const author = authorName(data.author);
+
+// Skill-only install affordances. Non-skill entries keep their existing render.
+const isSkill = data.type === 'skill';
+const repoUrl = data.repoUrl;
+const downloadUrl = data.downloadKey ? `/library/download/${slug}.skill` : null;
+const cloneCommand = repoUrl ? `git clone ${repoUrl} ~/.claude/skills/${slug}` : null;
 
 const breadcrumb = {
   '@context': 'https://schema.org',
@@ -71,6 +78,30 @@ const softwareSchema = {
   ...(data.updatedAt && { dateModified: data.updatedAt.toISOString().slice(0, 10) }),
 };
 
+// Skills are apps, not source snippets: emit SoftwareApplication instead of
+// SoftwareSourceCode (the other 4 types keep softwareSchema above).
+const skillAppSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: data.name,
+  description: data.description,
+  url: pageUrl,
+  applicationCategory: 'DeveloperApplication',
+  operatingSystem: 'Claude Code',
+  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  author: { '@type': 'Person', name: author },
+  keywords: data.tags.join(', '),
+  isAccessibleForFree: data.access === 'free',
+  ...(repoUrl && { codeRepository: repoUrl }),
+  isPartOf: {
+    '@type': 'CollectionPage',
+    name: 'Claude Code Marketing Library',
+    url: `${siteUrl}/library/`,
+  },
+  ...(data.publishedAt && { datePublished: data.publishedAt.toISOString().slice(0, 10) }),
+  ...(data.updatedAt && { dateModified: data.updatedAt.toISOString().slice(0, 10) }),
+};
+
 const faqSchema = {
   '@context': 'https://schema.org',
   '@type': 'FAQPage',
@@ -94,7 +125,7 @@ const faqSchema = {
 >
   <Header />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumb)} />
-  <script type="application/ld+json" set:html={JSON.stringify(softwareSchema)} />
+  <script type="application/ld+json" set:html={JSON.stringify(isSkill ? skillAppSchema : softwareSchema)} />
   <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
 
   <main class="lib-entry">
@@ -122,6 +153,62 @@ const faqSchema = {
         <p class="lib-entry-tagline">{data.tagline}</p>
         <p class="lib-entry-desc">{data.description}</p>
         <p class="lib-entry-by">By {author}</p>
+
+        {isSkill && (
+          <div class="lib-skill-install-wrap">
+            <div class="lib-skill-actions">
+              {repoUrl && (
+                <a href={repoUrl} target="_blank" rel="noopener" class="lib-skill-action lib-skill-action-primary">
+                  View on GitHub
+                </a>
+              )}
+              <button
+                type="button"
+                class="lib-skill-action lib-skill-add-btn"
+                data-skill-add
+                data-slug={slug}
+                data-name={data.name}
+                data-repo={repoUrl}
+                data-download-url={downloadUrl}
+                data-page-url={pageUrl}
+                aria-pressed="false"
+              >
+                <span data-add-label>Add to stack</span>
+              </button>
+            </div>
+
+            <section class="lib-skill-install" data-install-panel>
+              <h2 class="lib-skill-install-title">Install</h2>
+
+              <div class="lib-skill-tabs" role="tablist" aria-label="Install methods">
+                {cloneCommand && (
+                  <button type="button" class="lib-skill-tab" role="tab" id="lib-tab-clone" aria-controls="lib-panel-clone" aria-selected="true" data-tab="clone">git clone</button>
+                )}
+                {downloadUrl && (
+                  <button type="button" class="lib-skill-tab" role="tab" id="lib-tab-download" aria-controls="lib-panel-download" aria-selected={cloneCommand ? 'false' : 'true'} data-tab="download">Download</button>
+                )}
+              </div>
+
+              {cloneCommand && (
+                <div class="lib-skill-tabpanel" id="lib-panel-clone" role="tabpanel" aria-labelledby="lib-tab-clone" data-panel="clone">
+                  <p class="lib-skill-tabpanel-lead">Clone the skill straight into your Claude Code skills directory, then restart Claude Code.</p>
+                  <pre><code>{cloneCommand}</code></pre>
+                </div>
+              )}
+
+              {downloadUrl && (
+                <div class="lib-skill-tabpanel" id="lib-panel-download" role="tabpanel" aria-labelledby="lib-tab-download" data-panel="download" hidden={!!cloneCommand}>
+                  <p class="lib-skill-tabpanel-lead">Download the packaged skill, move it into <code>~/.claude/skills/</code>, then restart Claude Code.</p>
+                  <a href={downloadUrl} class="lib-skill-action lib-skill-action-primary" download={`${slug}.skill`}>Download {slug}.skill</a>
+                </div>
+              )}
+
+              {!cloneCommand && !downloadUrl && (
+                <p class="lib-skill-install-note">Install for this skill is available at launch.</p>
+              )}
+            </section>
+          </div>
+        )}
 
         <div class="prose">
           <Content />
@@ -151,8 +238,40 @@ const faqSchema = {
     </div>
   </main>
 
+  {isSkill && <StackCart />}
+
   <Footer />
 </BaseLayout>
+
+{isSkill && (
+  <script>
+    // Tabbed install panel: switch active tab/panel. Scoped to [data-install-panel].
+    function setupInstallTabs(): void {
+      document.querySelectorAll<HTMLElement>('[data-install-panel]').forEach((panel) => {
+        const tabs = panel.querySelectorAll<HTMLElement>('.lib-skill-tab');
+        const panes = panel.querySelectorAll<HTMLElement>('.lib-skill-tabpanel');
+        tabs.forEach((tab) => {
+          if (tab.dataset.tabBound) return;
+          tab.dataset.tabBound = '1';
+          tab.addEventListener('click', () => {
+            const target = tab.dataset.tab;
+            tabs.forEach((t) => t.setAttribute('aria-selected', String(t === tab)));
+            panes.forEach((p) => {
+              p.hidden = p.dataset.panel !== target;
+            });
+          });
+        });
+      });
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', setupInstallTabs);
+    } else {
+      setupInstallTabs();
+    }
+    window.addEventListener('pageshow', setupInstallTabs);
+  </script>
+)}
 
 <style>
   .lib-entry {
@@ -310,4 +429,101 @@ const faqSchema = {
     .lib-entry-layout { grid-template-columns: 1fr; gap: 28px; }
     .lib-entry-aside { order: 2; }
   }
+
+  /* Skill-only install block (rendered only when data.type === 'skill'). */
+  .lib-skill-install-wrap { margin: 0 0 32px; }
+
+  .lib-skill-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 24px;
+  }
+
+  .lib-skill-action {
+    display: inline-block;
+    font-size: 0.9em;
+    font-weight: 600;
+    text-decoration: none;
+    color: var(--rust);
+    border: 2px solid var(--rust);
+    padding: 10px 22px;
+    transition: all 0.2s ease;
+  }
+
+  .lib-skill-action:hover { background: var(--rust); color: var(--cream); }
+
+  .lib-skill-action-primary { background: var(--rust); color: var(--cream); }
+  .lib-skill-action-primary:hover { background: var(--charcoal); border-color: var(--charcoal); }
+
+  .lib-skill-add-btn {
+    cursor: pointer;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    border-color: var(--border-color);
+  }
+
+  .lib-skill-add-btn:hover { background: var(--bg-primary); border-color: var(--rust); color: var(--rust); }
+  .lib-skill-add-btn.in-stack { background: var(--rust); border-color: var(--rust); color: var(--cream); }
+
+  .lib-skill-install {
+    background: var(--bg-secondary);
+    border: 2px solid var(--border-color);
+    padding: 24px 28px;
+  }
+
+  .lib-skill-install-title {
+    font-family: var(--font-display);
+    font-size: 1.3em;
+    margin: 0 0 16px;
+    color: var(--text-primary);
+  }
+
+  .lib-skill-tabs {
+    display: flex;
+    margin-bottom: 16px;
+    border-bottom: 2px solid var(--border-color);
+  }
+
+  .lib-skill-tab {
+    background: transparent;
+    border: none;
+    border-bottom: 3px solid transparent;
+    margin-bottom: -2px;
+    padding: 8px 16px;
+    font-size: 0.9em;
+    font-weight: 600;
+    color: var(--text-secondary);
+    cursor: pointer;
+  }
+
+  .lib-skill-tab[aria-selected='true'] { color: var(--rust); border-bottom-color: var(--rust); }
+
+  .lib-skill-tabpanel-lead {
+    font-size: 0.9em;
+    color: var(--text-secondary);
+    margin: 0 0 12px;
+    line-height: 1.5;
+  }
+
+  .lib-skill-tabpanel-lead code {
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    padding: 1px 6px;
+  }
+
+  .lib-skill-install pre {
+    background: #1c1c1c;
+    color: #eaeaea;
+    border: 2px solid #2a2a2a;
+    padding: 16px;
+    overflow-x: auto;
+    margin: 0;
+    font-size: 0.85em;
+  }
+
+  .lib-skill-install pre code { color: inherit; background: transparent; border: none; padding: 0; }
+  .lib-skill-install code { font-size: 0.85em; }
+
+  .lib-skill-install-note { margin: 0; font-size: 0.9em; color: var(--text-secondary); }
 </style>

--- a/src/pages/library/download/[slug].skill.ts
+++ b/src/pages/library/download/[slug].skill.ts
@@ -1,0 +1,59 @@
+import type { APIRoute } from 'astro';
+import { getLibraryEntryBySlug } from '../../../lib/library';
+
+export const prerender = false;
+
+const NOT_FOUND_CACHE_CONTROL = 'public, max-age=300';
+const DOWNLOAD_CACHE_CONTROL = 'public, max-age=31536000, immutable';
+
+export const GET: APIRoute = async ({ params }) => {
+  const slug = params.slug ?? '';
+
+  // Validate the slug against the known collection BEFORE building any R2 key.
+  // This prevents arbitrary-key fetches / path traversal (e.g. ../../secret):
+  // only slugs that map to a real skill entry can reach R2 at all.
+  const entry = await getLibraryEntryBySlug(slug);
+
+  if (!entry || !entry.data.downloadKey) {
+    return notFound();
+  }
+
+  const { env } = await import('cloudflare:workers');
+  const media = (env as { MEDIA?: R2Bucket }).MEDIA;
+
+  // Local dev / missing binding: degrade to a friendly 404 rather than a 500.
+  if (!media) {
+    return notFound('Download unavailable in this environment.');
+  }
+
+  // downloadKey is a fixed string from validated frontmatter; its slug has
+  // already been confirmed to exist in the collection.
+  const r2Key = `skills/${entry.data.downloadKey}`;
+  const obj = await media.get(r2Key).catch(() => null);
+
+  if (!obj) {
+    return notFound();
+  }
+
+  const body = await obj.arrayBuffer();
+  return new Response(body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'Content-Disposition': `attachment; filename="${slug}.skill"`,
+      'Cache-Control': DOWNLOAD_CACHE_CONTROL,
+      'X-Robots-Tag': 'noindex',
+    },
+  });
+};
+
+function notFound(message = 'Skill download not found.'): Response {
+  return new Response(message, {
+    status: 404,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': NOT_FOUND_CACHE_CONTROL,
+      'X-Robots-Tag': 'noindex',
+    },
+  });
+}


### PR DESCRIPTION
## What

Fold PR #25's `/skills` gallery into the Marketing Library (one directory), per the decision to consolidate. Ports only the net-new mechanics; every existing library file stays. Closes #25.

### Mechanics (gated on `type === 'skill'`, 21 existing entries unchanged)
- Schema: optional `repoUrl`, `downloadKey`
- `stack-cart` component (route-agnostic via data-attrs, localStorage, cross-tab sync)
- R2 download route `/library/download/[slug].skill` (slug-validated, 404-not-500, noindex)
- Entry page: skill-only install tabs (git clone / download), View on GitHub, add-to-stack, `SoftwareApplication` JSON-LD (`SoftwareSourceCode` kept for the other 4 types)
- `CodeBlockCopy` skip for the cart pre; 301 `/skills` and `/skills/*` -> `/library/`

### Skills brought over (4, library now 25 entries)
- Notes Humanizer (content, free): installs via git clone from new public repo `cc4-marketing/notes-humanizer`
- Campaign Review Dashboard (project-ops), Last 30 Days (competitive), Slide Deck Builder (reporting): paid $19.99, install gated until Polar (preview + "available at launch")

### Packaging decision
Free skills: public GitHub repo, git clone. Paid packs: R2 gated download via Polar (later). See plans/20260722-0210-library-skills-fold/plan.md.

## Verify
- `npm run build` completes; 25 entries, OG covers generated
- free skill: git-clone tab + add-to-stack + SoftwareApplication; paid skill: "install available at launch", no clone; non-skill entry: no cart (unchanged); download route for a keyless slug: 404 not 500

## Dropped from #25
skills routes, skills collection, Skills nav, skillPages sitemap, skills OG key, separate llms Skills section (library already owns these). #25 to be closed.
